### PR TITLE
Implement Array and Associative Array Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-Wall -Wextra -Iinclude
+CFLAGS=-O3 -Wall -Wextra -Wconversion -Wnull-dereference -Wshadow -Wlogical-op -Wuninitialized -fstrict-aliasing -Werror -Iinclude
 LDFLAGS=-static -Wl,--warn-common
 AR=ar
 ARFLAGS=rcs
@@ -24,6 +24,9 @@ $(TARGET): $(OBJS) $(BUILTIN_LIB)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@
+
+lex.yy.o: lex.yy.c
+	$(CC) $(CFLAGS) -Wno-null-dereference -Wno-error=null-dereference -c $< -o $@
 
 clean:
 	rm -f $(OBJS) $(BUILTIN_OBJS) $(TARGET) $(BUILTIN_LIB)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILTIN_SRCS=$(wildcard builtin/*.c)
 BUILTIN_OBJS=$(BUILTIN_SRCS:.c=.o)
 BUILTIN_LIB=lib/libbuiltin.a
 
-SRCS=main.c array.c builtin.c error.c execute.c expr.c file.c job.c parser.tab.c lex.yy.c log.c map.c memory.c pipeline.c redirect.c strconv.c string.c variable.c
+SRCS=main.c array.c builtin.c error.c execute.c expr.c file.c iterator.c job.c parser.tab.c lex.yy.c log.c map.c memory.c pipeline.c redirect.c strconv.c string.c variable.c
 OBJS=$(SRCS:.c=.o)
 
 TARGET=rickshell

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILTIN_SRCS=$(wildcard builtin/*.c)
 BUILTIN_OBJS=$(BUILTIN_SRCS:.c=.o)
 BUILTIN_LIB=lib/libbuiltin.a
 
-SRCS=main.c builtin.c error.c execute.c expr.c file.c job.c parser.tab.c lex.yy.c log.c map.c memory.c pipeline.c redirect.c strconv.c string.c variable.c
+SRCS=main.c array.c builtin.c error.c execute.c expr.c file.c job.c parser.tab.c lex.yy.c log.c map.c memory.c pipeline.c redirect.c strconv.c string.c variable.c
 OBJS=$(SRCS:.c=.o)
 
 TARGET=rickshell

--- a/array.c
+++ b/array.c
@@ -7,8 +7,7 @@
 static void array_grow(array* a) {
   if (array_has_flag(a, ArrayFlag_Fixed)) return;
   size_t new_capacity = a->capacity == 0 ? 1 : a->capacity * 2;
-  void* new_data = rrealloc(a->data, new_capacity * a->element_size);
-  a->data = new_data;
+  a->data = rrealloc(a->data, new_capacity * a->element_size);
   a->capacity = new_capacity;
 }
 

--- a/array.c
+++ b/array.c
@@ -1,0 +1,180 @@
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+#include "array.h"
+#include "memory.h"
+
+static void array_grow(array* a) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  size_t new_capacity = a->capacity == 0 ? 1 : a->capacity * 2;
+  void* new_data = rrealloc(a->data, new_capacity * a->element_size);
+  a->data = new_data;
+  a->capacity = new_capacity;
+}
+
+array create_array(size_t element_size) {
+  array a;
+  a.data = rcalloc(1, element_size);
+  a.size = 0;
+  a.capacity = 1;
+  a.element_size = element_size;
+  a.flags = 0;
+  return a;
+}
+
+array create_array_with_first_element(size_t element_size, void* fe) {
+  array a = create_array(element_size);
+  array_push(&a, fe);
+  return a;
+}
+
+array create_array_with_capacity(size_t element_size, size_t capacity) {
+  array a;
+  a.data = rcalloc(capacity, element_size);
+  a.size = 0;
+  a.capacity = capacity;
+  a.element_size = element_size;
+  a.flags = 0;
+  return a;
+}
+
+void* array_get_first(array a) {
+  return a.size > 0 ? a.data : NULL;
+}
+
+void* array_get_last(array a) {
+  return a.size > 0 ? (char*)a.data + (a.size - 1) * a.element_size : NULL;
+}
+
+void* array_get(array a, size_t index) {
+  return index < a.size ? (char*)a.data + index * a.element_size : NULL;
+}
+
+void* array_checked_get(array a, size_t index) {
+  assert(index < a.size && "Index out of bounds");
+  return array_get(a, index);
+}
+
+void array_delete_first(array* a) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  if (a->size > 0) {
+    memmove(a->data, (char*)a->data + a->element_size, (a->size - 1) * a->element_size);
+    a->size--;
+    memset((char*)a->data + a->size * a->element_size, 0, a->element_size);
+  }
+}
+
+void array_delete_last(array* a) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  if (a->size > 0) {
+    a->size--;
+    memset((char*)a->data + a->size * a->element_size, 0, a->element_size);
+  }
+}
+
+void array_trim(array* a, size_t index) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  if (index < a->size) {
+    memset((char*)a->data + index * a->element_size, 0, (a->size - index) * a->element_size);
+    a->size = index;
+  }
+}
+
+void array_drop_item(array* a, size_t num) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  if (num > a->size) {
+    num = a->size;
+  }
+  memmove(a->data, (char*)a->data + num * a->element_size, (a->size - num) * a->element_size);
+  memset((char*)a->data + (a->size - num) * a->element_size, 0, num * a->element_size);
+  a->size -= num;
+}
+
+void array_drop_item_index(array* a, size_t index, size_t num) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  if (index >= a->size) return;
+  if (index + num > a->size) {
+    num = a->size - index;
+  }
+  memmove((char*)a->data + index * a->element_size, 
+          (char*)a->data + (index + num) * a->element_size, 
+          (a->size - index - num) * a->element_size);
+  memset((char*)a->data + (a->size - num) * a->element_size, 0, num * a->element_size);
+  a->size -= num;
+}
+
+void array_clone(array* dest, array* src) {
+  dest->element_size = src->element_size;
+  dest->size = src->size;
+  dest->capacity = src->capacity;
+  dest->flags = src->flags;
+  dest->data = malloc(src->capacity * src->element_size);
+  if (dest->data == NULL) {
+    assert(0 && "Memory allocation failed");
+    return;
+  }
+  memcpy(dest->data, src->data, src->size * src->element_size);
+}
+
+void array_index_set(array* a, size_t index, void* value) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  assert(index < a->size && "Index out of bounds");
+  memcpy((char*)a->data + index * a->element_size, value, a->element_size);
+}
+
+void array_push(array* a, void* value) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  if (a->size == a->capacity) array_grow(a);
+  memcpy((char*)a->data + a->size * a->element_size, value, a->element_size);
+  a->size++;
+}
+
+void array_push_repeat(array* a, void* value, size_t num) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  for (size_t i = 0; i < num; i++)
+    array_push(a, value);
+}
+
+void array_push_repeat_index(array* a, size_t index, void* value, size_t num) {
+  if (array_has_flag(a, ArrayFlag_Fixed)) return;
+  assert(index <= a->size && "Index out of bounds");
+  size_t new_size = a->size + num;
+  while (new_size > a->capacity) array_grow(a);
+  memmove((char*)a->data + (index + num) * a->element_size,
+          (char*)a->data + index * a->element_size,
+          (a->size - index) * a->element_size);
+  for (size_t i = 0; i < num; i++) {
+    memcpy((char*)a->data + (index + i) * a->element_size, value, a->element_size);
+  }
+  a->size = new_size;
+}
+
+array array_slice(array* a, size_t start, size_t end) {
+  assert(start <= end && end <= a->size && "Invalid slice range");
+  array slice = create_array(a->element_size);
+  size_t slice_size = end - start;
+  slice.data = malloc(slice_size * a->element_size);
+  if (slice.data == NULL) {
+    assert(0 && "Memory allocation failed");
+    return slice;
+  }
+  memcpy(slice.data, (char*)a->data + start * a->element_size, slice_size * a->element_size);
+  slice.size = slice_size;
+  slice.capacity = slice_size;
+  return slice;
+}
+
+void array_free(array* a) {
+  if (a->data) {
+    memset(a->data, 0, a->capacity * a->element_size);
+    free(a->data);
+    a->data = NULL;
+  }
+  a->size = 0;
+  a->capacity = 0;
+}
+
+void array_set_flag(array* a, ArrayFlag flag) { a->flags |= flag; }
+void array_clear_flag(array* a, ArrayFlag flag) { a->flags &= ~flag; }
+int array_has_flag(array* a, ArrayFlag flag) { return (a->flags & flag) != 0; }
+void array_toggle_flag(array* a, ArrayFlag flag) { a->flags ^= flag; }

--- a/builtin/cd.c
+++ b/builtin/cd.c
@@ -80,12 +80,14 @@ static char *find_cd_path(const char *dir) {
   
   path = strtok_r(cdpath_copy, ":", &saveptr);
   while (path != NULL) {
-    snprintf(full_path, sizeof(full_path), "%s/%s", path, dir);
-    if (access(full_path, F_OK) == 0) {
-      free(cdpath_copy);
-      return full_path;
+    if (strlen(path) + strlen(dir) + 1 < sizeof(full_path)) {
+      snprintf(full_path, sizeof(full_path), "%s/%s", path, dir);
+      if (access(full_path, F_OK) == 0) {
+        free(cdpath_copy);
+        return full_path;
+      }
+      path = strtok_r(NULL, ":", &saveptr);
     }
-    path = strtok_r(NULL, ":", &saveptr);
   }
   
   free(cdpath_copy);
@@ -127,6 +129,7 @@ int builtin_cd(Command *cmd) {
       return 1;
     }
   }
+  (void)physical;
 
   if (dir == NULL) {
     dir = getenv("HOME");

--- a/builtin/readonly.c
+++ b/builtin/readonly.c
@@ -35,9 +35,9 @@ int builtin_readonly(Command *cmd) {
             return 1;
         }
       }
-      option_end = i + 1;
+      option_end = (int)i + 1;
     } else if (strcmp(cmd->argv.data[i], "--") == 0) {
-      option_end = i + 1;
+      option_end = (int)i + 1;
       break;
     } else {
       break;
@@ -48,13 +48,15 @@ int builtin_readonly(Command *cmd) {
     for (int i = 0; i < variable_table->size; i++) {
       Variable *var = &variable_table->variables[i];
       if (is_variable_flag_set(&var->flags, VarFlag_ReadOnly)) {
-        array_print(variable_table, var->name);
+        char* value = va_value_to_string(&var->data);
+        printf("readonly %s=%s\n", var->name, value);
+        rfree(value);
       }
     }
     return 0;
   }
 
-  for (size_t i = option_end; i < cmd->argv.size; i++) {
+  for (size_t i = (size_t)option_end; i < cmd->argv.size; i++) {
     char *arg = cmd->argv.data[i];
     char *equals = strchr(arg, '=');
     char *name, *value = NULL;

--- a/builtin/readonly.c
+++ b/builtin/readonly.c
@@ -7,6 +7,7 @@
 #include "error.h"
 #include "expr.h"
 #include "memory.h"
+#include "array.h"
 
 extern VariableTable* variable_table;
 
@@ -47,9 +48,7 @@ int builtin_readonly(Command *cmd) {
     for (int i = 0; i < variable_table->size; i++) {
       Variable *var = &variable_table->variables[i];
       if (is_variable_flag_set(&var->flags, VarFlag_ReadOnly)) {
-        for (int j = 0; j < var->array_size; j++) {
-          printf("readonly %s[%d]=%s\n", var->name, j, var->data._array[j]);
-        }
+        array_print(variable_table, var->name);
       }
     }
     return 0;

--- a/execute.c
+++ b/execute.c
@@ -68,7 +68,7 @@ int execute_command(Command* cmd) {
         }
         array_set_element(variable_table, name, (size_t)index, value);
       } else {
-        print_error("Invalid value for associative array");
+        print_error("Variable is not an array or associative array");
         return -1;
       }
     } else if (value[0] == '(' && value[strlen(value) - 1] == ')') {

--- a/execute.c
+++ b/execute.c
@@ -51,7 +51,11 @@ int execute_command(Command* cmd) {
     if (*value == '\0' && cmd->argv.data[1] != NULL)
       value = cmd->argv.data[1];
     
-    if (open_bracket && close_bracket && open_bracket < close_bracket) {
+    if (value[0] == '(' && value[strlen(value) - 1] == ')') {
+      parse_and_set_array(variable_table, name, value);
+    } if (value[0] == '{' && value[strlen(value) - 1] == '}') {
+      parse_and_set_associative_array(variable_table, name, value);
+    } else if (open_bracket && close_bracket && open_bracket < close_bracket) {
       *open_bracket = '\0';
       *close_bracket = '\0';
       char* key = open_bracket + 1;
@@ -71,8 +75,6 @@ int execute_command(Command* cmd) {
         print_error("Variable is not an array or associative array");
         return -1;
       }
-    } else if (value[0] == '(' && value[strlen(value) - 1] == ')') {
-      parse_and_set_array(variable_table, name, value);
     } else {
       Variable* var = set_variable(variable_table, name, value, parse_variable_type(value), false);
       if (var == NULL) {

--- a/include/array.h
+++ b/include/array.h
@@ -1,0 +1,41 @@
+#ifndef __RICKSHELL_ARRAY_H__
+#define __RICKSHELL_ARRAY_H__
+#include <stddef.h>
+
+typedef enum {
+  ArrayFlag_Fixed = 1U << 0,
+} ArrayFlag;
+
+typedef struct {
+  void* data;
+  size_t size;
+  size_t capacity;
+  size_t element_size;
+  ArrayFlag flags;
+} array;
+
+void array_set_flag(array* a, ArrayFlag flag);
+void array_clear_flag(array* a, ArrayFlag flag);
+int array_has_flag(array* a, ArrayFlag flag);
+void array_toggle_flag(array* a, ArrayFlag flag);
+
+array create_array(size_t element_size);
+array create_array_with_first_element(size_t element_size, void* fe);
+array create_array_with_capacity(size_t element_size, size_t capacity);
+void* array_get_first(array a);
+void* array_get_last(array a);
+void* array_get(array a, size_t index);
+void* array_checked_get(array a, size_t index);
+void array_delete_first(array* a);
+void array_delete_last(array* a);
+void array_trim(array* a, size_t index);
+void array_drop_item(array* a, size_t num);
+void array_drop_item_index(array* a, size_t index, size_t num);
+void array_clone(array* dest, array* src);
+void array_index_set(array* a, size_t index, void* value);
+void array_push(array* a, void* value);
+void array_push_repeat(array* a, void* value, size_t num);
+void array_push_repeat_index(array* a, size_t index, void* value, size_t num);
+array array_slice(array* a, size_t start, size_t end);
+void array_free(array* a);
+#endif

--- a/include/iterator.h
+++ b/include/iterator.h
@@ -1,0 +1,17 @@
+#ifndef __RICKSHELL_ITERATOR_H__
+#define __RICKSHELL_ITERATOR_H__
+#include "map.h"
+
+typedef struct {
+  const map* m;
+  size_t current_index;
+  size_t items_returned;
+} MapIterator;
+
+MapIterator map_iterator(const map* m);
+bool map_has_next(MapIterator* it);
+const char* map_next(MapIterator* it);
+void* map_iterator_get_value(MapIterator* it, size_t* out_value_size);
+MapResult map_iterator_peek(MapIterator* it, const char** out_key, void** out_value, size_t* out_value_size);
+void map_iterator_reset(MapIterator* it);
+#endif /* __RICKSHELL_ITERATOR_H__ */

--- a/include/map.h
+++ b/include/map.h
@@ -12,7 +12,6 @@ typedef struct {
   void* value;
   size_t value_size;
   bool is_occupied;
-  bool is_deleted;
 } map_kv;
 
 typedef struct {
@@ -37,5 +36,5 @@ MapResult resize_map(map* m, size_t new_capacity);
 MapResult map_insert(map* m, const char* key, void* value, size_t value_size);
 MapResult map_get(const map* m, const char* key, void* out_value, size_t* out_value_size);
 bool map_remove(map* m, const char* key);
-void free_map(map* m);
+void map_free(map* m);
 #endif /* __RICKSHELL_MAP_H__ */

--- a/include/map.h
+++ b/include/map.h
@@ -14,13 +14,15 @@ typedef struct {
   bool is_occupied;
 } map_kv;
 
+typedef void (*MapFreeFn)(void*);
+
 typedef struct {
   map_kv* buckets;
   size_t capacity;
   size_t size;
   size_t num_deleted;
   pthread_mutex_t lock;
-  void (*value_free)(void*);
+  MapFreeFn value_free;
 } map;
 
 typedef enum {
@@ -31,6 +33,7 @@ typedef enum {
   MAP_ERROR_INVALID_ARGUMENT
 } MapErrCode;
 
+map* create_map_with_func(MapFreeFn value_free);
 map* create_map();
 MapResult resize_map(map* m, size_t new_capacity);
 MapResult map_insert(map* m, const char* key, void* value, size_t value_size);

--- a/include/rick.h
+++ b/include/rick.h
@@ -1,5 +1,10 @@
 #ifndef __RICKSHELL_RICK_H__
 #define __RICKSHELL_RICK_H__
+
+#if defined(_WEIRD_DEFINE_LIKE_HYUNSEO_HOODIES_DEBUG_REALLOC)
+  #undef _WEIRD_DEFINE_LIKE_HYUNSEO_HOODIES_DEBUG_REALLOC
+#endif
+
 typedef struct Redirect Redirect;
 typedef enum   RedirectType RedirectType;
 #endif /* __RICKSHELL_RICK_H__ */

--- a/include/rstring.h
+++ b/include/rstring.h
@@ -1,4 +1,7 @@
 #ifndef __RICKSHELL_RSTRING_H__
 #define __RICKSHELL_RSTRING_H__
 char* remove_quotes(const char* str);
+void ltrim(char* str);
+void rtrim(char* str);
+void trim(char* str);
 #endif /* __RICKSHELL_RSTRING_H__ */

--- a/include/rstring.h
+++ b/include/rstring.h
@@ -1,6 +1,13 @@
 #ifndef __RICKSHELL_RSTRING_H__
 #define __RICKSHELL_RSTRING_H__
+#include <stdbool.h>
+
 char* remove_quotes(const char* str);
+char* str_replace(const char* src, const char* old, const char* new, bool replace_all);
+bool match_pattern(const char* str, const char* pattern);
+char* remove_prefix(const char* value, const char* pattern, bool is_longest_match);
+char* remove_suffix(const char* str, const char* suffix, bool greedy);
+char* dynstrcpy(char** dest, size_t* dest_size, size_t* dest_len, const char* src);
 void ltrim(char* str);
 void rtrim(char* str);
 void trim(char* str);

--- a/include/variable.h
+++ b/include/variable.h
@@ -62,6 +62,7 @@ Variable* get_variable(VariableTable* table, const char* name);
 void unset_variable(VariableTable* table, const char* name);
 void parse_and_set_array(VariableTable* table, const char* name, const char* value);
 void array_set_element(VariableTable* table, const char* name, size_t index, const char* value);
+void parse_and_set_associative_array(VariableTable* table, const char* name, const char* input);
 bool do_not_expand_this_builtin(const char* name);
 VariableType parse_variable_type(const char* value);
 Variable* resolve_nameref(Variable* var);
@@ -69,6 +70,7 @@ void set_associative_array_variable(VariableTable* table, const char* name, cons
 char* va_value_to_string(const va_value_t* value);
 va_value_t string_to_va_value(const char* str, VariableType type);
 void free_va_value(va_value_t* value);
+void vfree_va_value(void* value);
 void free_variable(Variable* var);
 void cleanup_variables();
 char* expand_variables(VariableTable* table, const char* input);

--- a/include/variable.h
+++ b/include/variable.h
@@ -64,4 +64,8 @@ Variable* resolve_nameref(Variable* var);
 void export_variable(VariableTable* table, const char* name);
 void set_array_variable(VariableTable* table, const char* name, char** values, int size);
 void init_variables();
+void set_associative_array_variable(VariableTable* table, const char* name, const char* key, const char* value);
+char* va_value_to_string(const va_value_t* value);
+va_value_t string_to_va_value(const char* str, VariableType type);
+void free_va_value(va_value_t* value);
 #endif /* __RICKSHELL_VARIABLE_H__ */

--- a/include/variable.h
+++ b/include/variable.h
@@ -64,6 +64,8 @@ Variable* resolve_nameref(Variable* var);
 void export_variable(VariableTable* table, const char* name);
 void set_array_variable(VariableTable* table, const char* name, char** values, int size);
 void init_variables();
+void cleanup_variables();
+void free_variable(Variable* var);
 void set_associative_array_variable(VariableTable* table, const char* name, const char* key, const char* value);
 char* va_value_to_string(const va_value_t* value);
 va_value_t string_to_va_value(const char* str, VariableType type);

--- a/include/variable.h
+++ b/include/variable.h
@@ -2,6 +2,7 @@
 #define __RICKSHELL_VARIABLE_H__
 #include <stdbool.h>
 #include "map.h"
+#include "array.h"
 
 typedef enum {
   VAR_STRING,
@@ -17,7 +18,7 @@ typedef struct {
     long long _number;
     double _float;
     map* _map;
-    char** _array;
+    array _array;
   };
   VariableType type;
 } va_value_t;
@@ -70,4 +71,11 @@ void set_associative_array_variable(VariableTable* table, const char* name, cons
 char* va_value_to_string(const va_value_t* value);
 va_value_t string_to_va_value(const char* str, VariableType type);
 void free_va_value(va_value_t* value);
+void array_print(VariableTable* table, const char* name);
+VariableType get_variable_type(const char* name);
+void parse_and_set_array(VariableTable* table, const char* name, const char* value);
+char* array_get_element(VariableTable* table, const char* name, size_t index);
+void array_add_element(VariableTable* table, const char* name, const char* value);
+void array_set_element(VariableTable* table, const char* name, size_t index, const char* value);
+void array_print(VariableTable* table, const char* name);
 #endif /* __RICKSHELL_VARIABLE_H__ */

--- a/include/variable.h
+++ b/include/variable.h
@@ -33,10 +33,6 @@ typedef enum {
   VarFlag_Lowercase    = 1U << 6,
 } va_flag_t;
 
-bool is_variable_flag_set(va_flag_t* vf, va_flag_t flag);
-void set_variable_flag(va_flag_t* vf, va_flag_t flag);
-void unset_variable_flag(va_flag_t* vf, va_flag_t flag);
-
 typedef struct {
   char* name;
   char* value;
@@ -53,29 +49,27 @@ typedef struct {
   int capacity;
 } VariableTable;
 
+bool is_variable_flag_set(va_flag_t* vf, va_flag_t flag);
+void set_variable_flag(va_flag_t* vf, va_flag_t flag);
+void unset_variable_flag(va_flag_t* vf, va_flag_t flag);
+
+void init_variables();
 VariableTable* create_variable_table();
 void free_variable_table(VariableTable* table);
+Variable* create_new_variable(VariableTable* table, const char* name, VariableType type);
 Variable* set_variable(VariableTable* table, const char* name, const char* value, VariableType type, bool readonly);
 Variable* get_variable(VariableTable* table, const char* name);
 void unset_variable(VariableTable* table, const char* name);
-char* expand_variables(VariableTable* table, const char* input);
+void parse_and_set_array(VariableTable* table, const char* name, const char* value);
+void array_set_element(VariableTable* table, const char* name, size_t index, const char* value);
 bool do_not_expand_this_builtin(const char* name);
 VariableType parse_variable_type(const char* value);
 Variable* resolve_nameref(Variable* var);
-void export_variable(VariableTable* table, const char* name);
-void set_array_variable(VariableTable* table, const char* name, char** values, int size);
-void init_variables();
-void cleanup_variables();
-void free_variable(Variable* var);
 void set_associative_array_variable(VariableTable* table, const char* name, const char* key, const char* value);
 char* va_value_to_string(const va_value_t* value);
 va_value_t string_to_va_value(const char* str, VariableType type);
 void free_va_value(va_value_t* value);
-void array_print(VariableTable* table, const char* name);
-VariableType get_variable_type(const char* name);
-void parse_and_set_array(VariableTable* table, const char* name, const char* value);
-char* array_get_element(VariableTable* table, const char* name, size_t index);
-void array_add_element(VariableTable* table, const char* name, const char* value);
-void array_set_element(VariableTable* table, const char* name, size_t index, const char* value);
-void array_print(VariableTable* table, const char* name);
+void free_variable(Variable* var);
+void cleanup_variables();
+char* expand_variables(VariableTable* table, const char* input);
 #endif /* __RICKSHELL_VARIABLE_H__ */

--- a/include/wyhash.h
+++ b/include/wyhash.h
@@ -153,10 +153,10 @@ static inline uint64_t wyhash64(uint64_t A, uint64_t B){ A^=0x2d358dccaa6c78a5ul
 static inline uint64_t wyrand(uint64_t *seed){ *seed+=0x2d358dccaa6c78a5ull; return _wymix(*seed,*seed^0x8bb84b93962eacc9ull);}
 
 //convert any 64 bit pseudo random numbers to uniform distribution [0,1). It can be combined with wyrand, wyhash64 or wyhash.
-static inline double wy2u01(uint64_t r){ const double _wynorm=1.0/(1ull<<52); return (r>>12)*_wynorm;}
+static inline double wy2u01(uint64_t r){ const double _wynorm=1.0/(1ull<<52); return (double)(r>>12)*_wynorm;}
 
 //convert any 64 bit pseudo random numbers to APPROXIMATE Gaussian distribution. It can be combined with wyrand, wyhash64 or wyhash.
-static inline double wy2gau(uint64_t r){ const double _wynorm=1.0/(1ull<<20); return ((r&0x1fffff)+((r>>21)&0x1fffff)+((r>>42)&0x1fffff))*_wynorm-3.0;}
+static inline double wy2gau(uint64_t r){ const double _wynorm=1.0/(1ull<<20); return ((double)((r & 0x1fffff) + ((r >> 21) & 0x1fffff) + ((r >> 42) & 0x1fffff)) * _wynorm) - 3.0;}
 
 #ifdef  WYTRNG
 #include <sys/time.h>

--- a/iterator.c
+++ b/iterator.c
@@ -1,0 +1,78 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include "iterator.h"
+
+MapIterator map_iterator(const map* m) {
+  MapIterator it = {m, 0, 0};
+  return it;
+}
+
+bool map_has_next(MapIterator* it) {
+  if (!it || !it->m) return false;
+  
+  while (it->current_index < it->m->capacity) {
+    if (it->m->buckets[it->current_index].is_occupied) {
+      return true;
+    }
+    it->current_index++;
+  }
+  return false;
+}
+
+const char* map_next(MapIterator* it) {
+  if (!it || !it->m) return NULL;
+  
+  while (it->current_index < it->m->capacity) {
+    if (it->m->buckets[it->current_index].is_occupied) {
+      const char* key = it->m->buckets[it->current_index].key;
+      it->current_index++;
+      it->items_returned++;
+      return key;
+    }
+    it->current_index++;
+  }
+  return NULL;
+}
+
+void* map_iterator_get_value(MapIterator* it, size_t* out_value_size) {
+  if (!it || !it->m || it->current_index == 0 || it->current_index > it->m->capacity) {
+    if (out_value_size) *out_value_size = 0;
+    return NULL;
+  }
+  
+  size_t index = it->current_index - 1;
+  if (it->m->buckets[index].is_occupied) {
+    if (out_value_size) *out_value_size = it->m->buckets[index].value_size;
+    return it->m->buckets[index].value;
+  }
+  
+  if (out_value_size) *out_value_size = 0;
+  return NULL;
+}
+
+MapResult map_iterator_peek(MapIterator* it, const char** out_key, void** out_value, size_t* out_value_size) {
+  if (!it || !it->m) return Err((void*)MAP_ERROR_INVALID_ARGUMENT);
+  
+  size_t current = it->current_index;
+  while (current < it->m->capacity) {
+    if (it->m->buckets[current].is_occupied) {
+      if (out_key) *out_key = it->m->buckets[current].key;
+      if (out_value) *out_value = it->m->buckets[current].value;
+      if (out_value_size) *out_value_size = it->m->buckets[current].value_size;
+      return Ok((void*)MAP_OK);
+    }
+    current++;
+  }
+  return Err((void*)MAP_ERROR_KEY_NOT_FOUND);
+}
+
+void map_iterator_reset(MapIterator* it) {
+  if (it) {
+    it->current_index = 0;
+    it->items_returned = 0;
+  }
+}

--- a/lex.yy.c
+++ b/lex.yy.c
@@ -348,8 +348,8 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-#define YY_NUM_RULES 27
-#define YY_END_OF_BUFFER 28
+#define YY_NUM_RULES 28
+#define YY_END_OF_BUFFER 29
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -357,13 +357,13 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[48] =
+static const flex_int16_t yy_accept[51] =
     {   0,
-        0,    0,   28,   27,    1,   15,   27,   26,   27,   11,
-       19,   20,   26,   12,    4,    5,   26,    3,    1,    0,
-        2,   26,   25,   24,    0,   13,    0,   21,   26,   16,
-       17,    7,    9,    8,    6,   26,    0,   14,   24,    0,
-       23,   18,   10,    0,   22,   22,    0
+        0,    0,   29,   28,    1,   15,   28,   27,   28,   11,
+       19,   20,   27,   12,    4,    5,   27,    3,    1,    0,
+        2,   27,   25,   24,    0,   13,    0,   21,   27,   16,
+       17,    7,    9,    8,    6,   27,    0,   14,   24,    0,
+        0,   23,   18,   10,    0,    0,   22,   26,   22,    0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -405,54 +405,56 @@ static const YY_CHAR yy_meta[23] =
         1,    1
     } ;
 
-static const flex_int16_t yy_base[54] =
+static const flex_int16_t yy_base[58] =
     {   0,
-        0,    0,   76,   77,   73,   77,   70,    0,    6,   65,
-       62,   77,   13,   77,   16,   20,   21,   50,   68,   65,
-       77,    0,   77,   18,   46,   77,   57,   77,    0,   77,
-       35,   77,   77,   77,   33,    0,    0,   77,   25,   18,
-       77,   77,   77,   15,   16,   77,   77,   42,   46,   48,
-       52,   57,   62
+        0,    0,   83,   84,   80,   84,   77,    0,    6,   72,
+       69,   84,   13,   84,   16,   20,   21,   57,   75,   72,
+       84,    0,   84,   23,   53,   84,   64,   84,    0,   84,
+       57,   84,   84,   84,   64,    0,    0,   84,   25,    0,
+       30,   84,   84,   84,   15,   12,   15,   84,   84,   84,
+       43,   47,   49,   53,   58,   63,   67
     } ;
 
-static const flex_int16_t yy_def[54] =
+static const flex_int16_t yy_def[58] =
     {   0,
-       47,    1,   47,   47,   47,   47,   48,   49,   50,   47,
-       51,   47,   49,   47,   47,   47,   49,   47,   47,   48,
-       47,   49,   47,   47,   52,   47,   51,   47,   13,   47,
-       47,   47,   47,   47,   47,   17,   53,   47,   47,   52,
-       47,   47,   47,   53,   47,   47,    0,   47,   47,   47,
-       47,   47,   47
+       50,    1,   50,   50,   50,   50,   51,   52,   53,   50,
+       54,   50,   52,   50,   50,   50,   52,   50,   50,   51,
+       50,   52,   50,   50,   55,   50,   54,   50,   13,   50,
+       50,   50,   50,   50,   50,   17,   56,   50,   50,   57,
+       55,   50,   50,   50,   56,   57,   50,   50,   50,    0,
+       50,   50,   50,   50,   50,   50,   50
     } ;
 
-static const flex_int16_t yy_nxt[100] =
+static const flex_int16_t yy_nxt[107] =
     {   0,
         4,    5,    6,    7,    8,    9,    8,   10,   11,   12,
         4,   13,   14,   15,    8,   16,   17,    4,    4,    4,
-       18,    4,   24,   32,   29,   25,   30,   34,   31,   39,
-       46,   33,   36,   45,   39,   35,   39,   36,   37,   41,
-       43,   39,   20,   20,   20,   20,   20,   22,   22,   23,
-       42,   23,   27,   27,   27,   27,   27,   40,   40,   40,
-       40,   40,   44,   44,   44,   44,   28,   41,   21,   19,
-       38,   28,   26,   21,   19,   47,    3,   47,   47,   47,
-       47,   47,   47,   47,   47,   47,   47,   47,   47,   47,
-       47,   47,   47,   47,   47,   47,   47,   47,   47
+       18,    4,   24,   32,   29,   25,   30,   34,   31,   49,
+       48,   33,   36,   47,   39,   35,   39,   36,   37,   39,
+       40,   39,   40,   20,   20,   20,   20,   20,   22,   22,
+       23,   42,   23,   27,   27,   27,   27,   27,   41,   41,
+       41,   41,   41,   45,   45,   45,   45,   46,   46,   46,
+       46,   44,   43,   28,   42,   21,   19,   38,   28,   26,
+       21,   19,   50,    3,   50,   50,   50,   50,   50,   50,
+       50,   50,   50,   50,   50,   50,   50,   50,   50,   50,
 
+       50,   50,   50,   50,   50,   50
     } ;
 
-static const flex_int16_t yy_chk[100] =
+static const flex_int16_t yy_chk[107] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    9,   15,   13,    9,   13,   16,   13,   24,
-       45,   15,   17,   44,   24,   16,   39,   17,   17,   40,
-       35,   39,   48,   48,   48,   48,   48,   49,   49,   50,
-       31,   50,   51,   51,   51,   51,   51,   52,   52,   52,
-       52,   52,   53,   53,   53,   53,   27,   25,   20,   19,
-       18,   11,   10,    7,    5,    3,   47,   47,   47,   47,
-       47,   47,   47,   47,   47,   47,   47,   47,   47,   47,
-       47,   47,   47,   47,   47,   47,   47,   47,   47
+        1,    1,    9,   15,   13,    9,   13,   16,   13,   47,
+       46,   15,   17,   45,   24,   16,   39,   17,   17,   24,
+       24,   39,   39,   51,   51,   51,   51,   51,   52,   52,
+       53,   41,   53,   54,   54,   54,   54,   54,   55,   55,
+       55,   55,   55,   56,   56,   56,   56,   57,   57,   57,
+       57,   35,   31,   27,   25,   20,   19,   18,   11,   10,
+        7,    5,    3,   50,   50,   50,   50,   50,   50,   50,
+       50,   50,   50,   50,   50,   50,   50,   50,   50,   50,
 
+       50,   50,   50,   50,   50,   50
     } ;
 
 static yy_state_type yy_last_accepting_state;
@@ -483,8 +485,8 @@ char *yytext;
 #define YY_NO_INPUT
 #define YY_NO_UNPUT
 
-#line 486 "lex.yy.c"
-#line 487 "lex.yy.c"
+#line 488 "lex.yy.c"
+#line 489 "lex.yy.c"
 
 #define INITIAL 0
 
@@ -703,7 +705,7 @@ YY_DECL
 	{
 #line 19 "lexer.l"
 
-#line 706 "lex.yy.c"
+#line 708 "lex.yy.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -730,13 +732,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 48 )
+				if ( yy_current_state >= 51 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 77 );
+		while ( yy_base[yy_current_state] != 84 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -891,16 +893,22 @@ YY_RULE_SETUP
 { yylval.str = strdup(yytext); return PARAM_EXPANSION; }
 	YY_BREAK
 case 26:
+/* rule 26 can match eol */
 YY_RULE_SETUP
 #line 45 "lexer.l"
-{ yylval.str = strdup(yytext); return WORD; }
+{ yylval.str = strdup(yytext); return PARAM_EXPANSION; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 47 "lexer.l"
+#line 46 "lexer.l"
+{ yylval.str = strdup(yytext); return WORD; }
+	YY_BREAK
+case 28:
+YY_RULE_SETUP
+#line 48 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 903 "lex.yy.c"
+#line 911 "lex.yy.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1193,7 +1201,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 48 )
+			if ( yy_current_state >= 51 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1221,11 +1229,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 48 )
+		if ( yy_current_state >= 51 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 47);
+	yy_is_jam = (yy_current_state == 50);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1901,7 +1909,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 47 "lexer.l"
+#line 48 "lexer.l"
 
 
 #undef YY_NO_INPUT

--- a/lex.yy.c
+++ b/lex.yy.c
@@ -348,8 +348,8 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-#define YY_NUM_RULES 25
-#define YY_END_OF_BUFFER 26
+#define YY_NUM_RULES 27
+#define YY_END_OF_BUFFER 28
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -357,12 +357,13 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[40] =
+static const flex_int16_t yy_accept[48] =
     {   0,
-        0,    0,   26,   25,    1,   15,   25,   24,   25,   11,
-       19,   20,   24,   12,    4,    5,    3,    1,    0,    2,
-       24,   23,   22,    0,   13,   24,   16,   17,    7,    9,
-        8,    6,   14,   22,    0,   21,   18,   10,    0
+        0,    0,   28,   27,    1,   15,   27,   26,   27,   11,
+       19,   20,   26,   12,    4,    5,   26,    3,    1,    0,
+        2,   26,   25,   24,    0,   13,    0,   21,   26,   16,
+       17,    7,    9,    8,    6,   26,    0,   14,   24,    0,
+       23,   18,   10,    0,   22,   22,    0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -373,14 +374,14 @@ static const YY_CHAR yy_ec[256] =
         1,    2,    1,    4,    5,    6,    7,    8,    1,    9,
        10,   11,    7,    1,    7,    7,    7,   12,   12,   12,
        12,   12,   12,   12,   12,   12,   12,    7,   13,   14,
-        7,   15,    7,   11,   16,   16,   16,   16,   16,   16,
-       16,   16,   16,   16,   16,   16,   16,   16,   16,   16,
-       16,   16,   16,   16,   16,   16,   16,   16,   16,   16,
-        1,    1,    1,    1,   16,    1,   16,   16,   16,   16,
+       15,   16,    7,   11,   17,   17,   17,   17,   17,   17,
+       17,   17,   17,   17,   17,   17,   17,   17,   17,   17,
+       17,   17,   17,   17,   17,   17,   17,   17,   17,   17,
+       18,    1,   19,    1,   17,    1,   17,   17,   17,   17,
 
-       16,   16,   16,   16,   16,   16,   16,   16,   16,   16,
-       16,   16,   16,   16,   16,   16,   16,   16,   16,   16,
-       16,   16,   17,   18,   19,    1,    1,    1,    1,    1,
+       17,   17,   17,   17,   17,   17,   17,   17,   17,   17,
+       17,   17,   17,   17,   17,   17,   17,   17,   17,   17,
+       17,   17,   20,   21,   22,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -397,52 +398,61 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static const YY_CHAR yy_meta[20] =
+static const YY_CHAR yy_meta[23] =
     {   0,
         1,    1,    1,    1,    2,    1,    3,    1,    1,    1,
-        4,    2,    1,    1,    1,    2,    4,    1,    1
+        4,    2,    1,    1,    3,    1,    2,    1,    5,    4,
+        1,    1
     } ;
 
-static const flex_int16_t yy_base[44] =
+static const flex_int16_t yy_base[54] =
     {   0,
-        0,    0,   55,   56,   52,   56,   49,    0,    4,   44,
-       56,   56,   10,   56,   15,   18,   33,   48,   45,   56,
-        0,   56,   15,   29,   56,    0,   56,   32,   56,   56,
-       56,   33,   56,   16,   10,   56,   56,   56,   56,   33,
-       36,   38,   42
+        0,    0,   76,   77,   73,   77,   70,    0,    6,   65,
+       62,   77,   13,   77,   16,   20,   21,   50,   68,   65,
+       77,    0,   77,   18,   46,   77,   57,   77,    0,   77,
+       35,   77,   77,   77,   33,    0,    0,   77,   25,   18,
+       77,   77,   77,   15,   16,   77,   77,   42,   46,   48,
+       52,   57,   62
     } ;
 
-static const flex_int16_t yy_def[44] =
+static const flex_int16_t yy_def[54] =
     {   0,
-       39,    1,   39,   39,   39,   39,   40,   41,   42,   39,
-       39,   39,   41,   39,   39,   39,   39,   39,   40,   39,
-       41,   39,   39,   43,   39,   13,   39,   39,   39,   39,
-       39,   39,   39,   39,   43,   39,   39,   39,    0,   39,
-       39,   39,   39
+       47,    1,   47,   47,   47,   47,   48,   49,   50,   47,
+       51,   47,   49,   47,   47,   47,   49,   47,   47,   48,
+       47,   49,   47,   47,   52,   47,   51,   47,   13,   47,
+       47,   47,   47,   47,   47,   17,   53,   47,   47,   52,
+       47,   47,   47,   53,   47,   47,    0,   47,   47,   47,
+       47,   47,   47
     } ;
 
-static const flex_int16_t yy_nxt[76] =
+static const flex_int16_t yy_nxt[100] =
     {   0,
         4,    5,    6,    7,    8,    9,    8,   10,   11,   12,
-        4,   13,   14,   15,   16,    8,    4,   17,    4,   23,
-       24,   26,   29,   27,   28,   31,   34,   34,   36,   30,
-       34,   34,   32,   19,   19,   19,   19,   21,   21,   22,
-       38,   22,   35,   35,   35,   35,   37,   36,   20,   18,
-       33,   25,   20,   18,   39,    3,   39,   39,   39,   39,
-       39,   39,   39,   39,   39,   39,   39,   39,   39,   39,
-       39,   39,   39,   39,   39
+        4,   13,   14,   15,    8,   16,   17,    4,    4,    4,
+       18,    4,   24,   32,   29,   25,   30,   34,   31,   39,
+       46,   33,   36,   45,   39,   35,   39,   36,   37,   41,
+       43,   39,   20,   20,   20,   20,   20,   22,   22,   23,
+       42,   23,   27,   27,   27,   27,   27,   40,   40,   40,
+       40,   40,   44,   44,   44,   44,   28,   41,   21,   19,
+       38,   28,   26,   21,   19,   47,    3,   47,   47,   47,
+       47,   47,   47,   47,   47,   47,   47,   47,   47,   47,
+       47,   47,   47,   47,   47,   47,   47,   47,   47
+
     } ;
 
-static const flex_int16_t yy_chk[76] =
+static const flex_int16_t yy_chk[100] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1,    1,    1,    1,    9,
-        9,   13,   15,   13,   13,   16,   23,   34,   35,   15,
-       23,   34,   16,   40,   40,   40,   40,   41,   41,   42,
-       32,   42,   43,   43,   43,   43,   28,   24,   19,   18,
-       17,   10,    7,    5,    3,   39,   39,   39,   39,   39,
-       39,   39,   39,   39,   39,   39,   39,   39,   39,   39,
-       39,   39,   39,   39,   39
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    9,   15,   13,    9,   13,   16,   13,   24,
+       45,   15,   17,   44,   24,   16,   39,   17,   17,   40,
+       35,   39,   48,   48,   48,   48,   48,   49,   49,   50,
+       31,   50,   51,   51,   51,   51,   51,   52,   52,   52,
+       52,   52,   53,   53,   53,   53,   27,   25,   20,   19,
+       18,   11,   10,    7,    5,    3,   47,   47,   47,   47,
+       47,   47,   47,   47,   47,   47,   47,   47,   47,   47,
+       47,   47,   47,   47,   47,   47,   47,   47,   47
+
     } ;
 
 static yy_state_type yy_last_accepting_state;
@@ -473,8 +483,8 @@ char *yytext;
 #define YY_NO_INPUT
 #define YY_NO_UNPUT
 
-#line 476 "lex.yy.c"
-#line 477 "lex.yy.c"
+#line 486 "lex.yy.c"
+#line 487 "lex.yy.c"
 
 #define INITIAL 0
 
@@ -693,7 +703,7 @@ YY_DECL
 	{
 #line 19 "lexer.l"
 
-#line 696 "lex.yy.c"
+#line 706 "lex.yy.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -720,13 +730,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 40 )
+				if ( yy_current_state >= 48 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 56 );
+		while ( yy_base[yy_current_state] != 77 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -856,14 +866,16 @@ case 21:
 /* rule 21 can match eol */
 YY_RULE_SETUP
 #line 40 "lexer.l"
-{ yylval.str = strdup(yytext); return PARAM_EXPANSION; }
+{ yylval.str = strdup(yytext); return WORD; }
 	YY_BREAK
 case 22:
+/* rule 22 can match eol */
 YY_RULE_SETUP
 #line 41 "lexer.l"
-{ yylval.str = strdup(yytext); return PARAM_EXPANSION; }
+{ yylval.str = strdup(yytext); return WORD; }
 	YY_BREAK
 case 23:
+/* rule 23 can match eol */
 YY_RULE_SETUP
 #line 42 "lexer.l"
 { yylval.str = strdup(yytext); return PARAM_EXPANSION; }
@@ -871,14 +883,24 @@ YY_RULE_SETUP
 case 24:
 YY_RULE_SETUP
 #line 43 "lexer.l"
-{ yylval.str = strdup(yytext); return WORD; }
+{ yylval.str = strdup(yytext); return PARAM_EXPANSION; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
+#line 44 "lexer.l"
+{ yylval.str = strdup(yytext); return PARAM_EXPANSION; }
+	YY_BREAK
+case 26:
+YY_RULE_SETUP
 #line 45 "lexer.l"
+{ yylval.str = strdup(yytext); return WORD; }
+	YY_BREAK
+case 27:
+YY_RULE_SETUP
+#line 47 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 881 "lex.yy.c"
+#line 903 "lex.yy.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1171,7 +1193,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 40 )
+			if ( yy_current_state >= 48 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1199,11 +1221,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 40 )
+		if ( yy_current_state >= 48 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 39);
+	yy_is_jam = (yy_current_state == 47);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1879,7 +1901,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 45 "lexer.l"
+#line 47 "lexer.l"
 
 
 #undef YY_NO_INPUT

--- a/lex.yy.c
+++ b/lex.yy.c
@@ -348,8 +348,8 @@ static void yynoreturn yy_fatal_error ( const char* msg  );
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-#define YY_NUM_RULES 28
-#define YY_END_OF_BUFFER 29
+#define YY_NUM_RULES 29
+#define YY_END_OF_BUFFER 30
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -357,13 +357,14 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[51] =
+static const flex_int16_t yy_accept[54] =
     {   0,
-        0,    0,   29,   28,    1,   15,   28,   27,   28,   11,
-       19,   20,   27,   12,    4,    5,   27,    3,    1,    0,
-        2,   27,   25,   24,    0,   13,    0,   21,   27,   16,
-       17,    7,    9,    8,    6,   27,    0,   14,   24,    0,
-        0,   23,   18,   10,    0,    0,   22,   26,   22,    0
+        0,    0,   30,   29,    1,   15,   29,   28,   29,   11,
+       19,   20,   28,   12,    4,    5,   28,   29,    3,    1,
+        0,    2,   28,   26,   25,    0,   13,    0,   21,   28,
+       16,   17,    7,    9,    8,    6,   28,    0,    0,   22,
+       14,   25,    0,    0,   24,   18,   10,    0,    0,   23,
+       27,   23,    0
     } ;
 
 static const YY_CHAR yy_ec[256] =
@@ -405,56 +406,60 @@ static const YY_CHAR yy_meta[23] =
         1,    1
     } ;
 
-static const flex_int16_t yy_base[58] =
+static const flex_int16_t yy_base[62] =
     {   0,
-        0,    0,   83,   84,   80,   84,   77,    0,    6,   72,
-       69,   84,   13,   84,   16,   20,   21,   57,   75,   72,
-       84,    0,   84,   23,   53,   84,   64,   84,    0,   84,
-       57,   84,   84,   84,   64,    0,    0,   84,   25,    0,
-       30,   84,   84,   84,   15,   12,   15,   84,   84,   84,
-       43,   47,   49,   53,   58,   63,   67
+        0,    0,   90,   91,   87,   91,   84,    0,    6,   79,
+       76,   91,   13,   91,   16,   20,   21,   63,   63,   81,
+       78,   91,    0,   91,   23,   59,   91,   70,   91,    0,
+       91,   63,   91,   91,   91,   70,    0,    0,   55,   91,
+       91,   25,    0,   30,   91,   91,   91,   15,   12,   15,
+       91,   91,   91,   43,   47,   49,   53,   58,   63,   68,
+       72
     } ;
 
-static const flex_int16_t yy_def[58] =
+static const flex_int16_t yy_def[62] =
     {   0,
-       50,    1,   50,   50,   50,   50,   51,   52,   53,   50,
-       54,   50,   52,   50,   50,   50,   52,   50,   50,   51,
-       50,   52,   50,   50,   55,   50,   54,   50,   13,   50,
-       50,   50,   50,   50,   50,   17,   56,   50,   50,   57,
-       55,   50,   50,   50,   56,   57,   50,   50,   50,    0,
-       50,   50,   50,   50,   50,   50,   50
+       53,    1,   53,   53,   53,   53,   54,   55,   56,   53,
+       57,   53,   55,   53,   53,   53,   55,   58,   53,   53,
+       54,   53,   55,   53,   53,   59,   53,   57,   53,   13,
+       53,   53,   53,   53,   53,   53,   17,   60,   58,   53,
+       53,   53,   61,   59,   53,   53,   53,   60,   61,   53,
+       53,   53,    0,   53,   53,   53,   53,   53,   53,   53,
+       53
     } ;
 
-static const flex_int16_t yy_nxt[107] =
+static const flex_int16_t yy_nxt[114] =
     {   0,
         4,    5,    6,    7,    8,    9,    8,   10,   11,   12,
-        4,   13,   14,   15,    8,   16,   17,    4,    4,    4,
-       18,    4,   24,   32,   29,   25,   30,   34,   31,   49,
-       48,   33,   36,   47,   39,   35,   39,   36,   37,   39,
-       40,   39,   40,   20,   20,   20,   20,   20,   22,   22,
-       23,   42,   23,   27,   27,   27,   27,   27,   41,   41,
-       41,   41,   41,   45,   45,   45,   45,   46,   46,   46,
-       46,   44,   43,   28,   42,   21,   19,   38,   28,   26,
-       21,   19,   50,    3,   50,   50,   50,   50,   50,   50,
-       50,   50,   50,   50,   50,   50,   50,   50,   50,   50,
+        4,   13,   14,   15,    8,   16,   17,    4,    4,   18,
+       19,    4,   25,   33,   30,   26,   31,   35,   32,   52,
+       51,   34,   37,   50,   42,   36,   42,   37,   38,   42,
+       43,   42,   43,   21,   21,   21,   21,   21,   23,   23,
+       24,   45,   24,   28,   28,   28,   28,   28,   39,   39,
+       39,   39,   39,   44,   44,   44,   44,   44,   48,   48,
+       48,   48,   49,   49,   49,   49,   40,   47,   46,   29,
+       45,   22,   20,   41,   40,   29,   27,   22,   20,   53,
+        3,   53,   53,   53,   53,   53,   53,   53,   53,   53,
 
-       50,   50,   50,   50,   50,   50
+       53,   53,   53,   53,   53,   53,   53,   53,   53,   53,
+       53,   53,   53
     } ;
 
-static const flex_int16_t yy_chk[107] =
+static const flex_int16_t yy_chk[114] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    9,   15,   13,    9,   13,   16,   13,   47,
-       46,   15,   17,   45,   24,   16,   39,   17,   17,   24,
-       24,   39,   39,   51,   51,   51,   51,   51,   52,   52,
-       53,   41,   53,   54,   54,   54,   54,   54,   55,   55,
-       55,   55,   55,   56,   56,   56,   56,   57,   57,   57,
-       57,   35,   31,   27,   25,   20,   19,   18,   11,   10,
-        7,    5,    3,   50,   50,   50,   50,   50,   50,   50,
-       50,   50,   50,   50,   50,   50,   50,   50,   50,   50,
+        1,    1,    9,   15,   13,    9,   13,   16,   13,   50,
+       49,   15,   17,   48,   25,   16,   42,   17,   17,   25,
+       25,   42,   42,   54,   54,   54,   54,   54,   55,   55,
+       56,   44,   56,   57,   57,   57,   57,   57,   58,   58,
+       58,   58,   58,   59,   59,   59,   59,   59,   60,   60,
+       60,   60,   61,   61,   61,   61,   39,   36,   32,   28,
+       26,   21,   20,   19,   18,   11,   10,    7,    5,    3,
+       53,   53,   53,   53,   53,   53,   53,   53,   53,   53,
 
-       50,   50,   50,   50,   50,   50
+       53,   53,   53,   53,   53,   53,   53,   53,   53,   53,
+       53,   53,   53
     } ;
 
 static yy_state_type yy_last_accepting_state;
@@ -485,8 +490,8 @@ char *yytext;
 #define YY_NO_INPUT
 #define YY_NO_UNPUT
 
-#line 488 "lex.yy.c"
-#line 489 "lex.yy.c"
+#line 493 "lex.yy.c"
+#line 494 "lex.yy.c"
 
 #define INITIAL 0
 
@@ -705,7 +710,7 @@ YY_DECL
 	{
 #line 19 "lexer.l"
 
-#line 708 "lex.yy.c"
+#line 713 "lex.yy.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -732,13 +737,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 51 )
+				if ( yy_current_state >= 54 )
 					yy_c = yy_meta[yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 84 );
+		while ( yy_base[yy_current_state] != 91 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -880,9 +885,10 @@ case 23:
 /* rule 23 can match eol */
 YY_RULE_SETUP
 #line 42 "lexer.l"
-{ yylval.str = strdup(yytext); return PARAM_EXPANSION; }
+{ yylval.str = strdup(yytext); return WORD; }
 	YY_BREAK
 case 24:
+/* rule 24 can match eol */
 YY_RULE_SETUP
 #line 43 "lexer.l"
 { yylval.str = strdup(yytext); return PARAM_EXPANSION; }
@@ -893,22 +899,27 @@ YY_RULE_SETUP
 { yylval.str = strdup(yytext); return PARAM_EXPANSION; }
 	YY_BREAK
 case 26:
-/* rule 26 can match eol */
 YY_RULE_SETUP
 #line 45 "lexer.l"
 { yylval.str = strdup(yytext); return PARAM_EXPANSION; }
 	YY_BREAK
 case 27:
+/* rule 27 can match eol */
 YY_RULE_SETUP
 #line 46 "lexer.l"
-{ yylval.str = strdup(yytext); return WORD; }
+{ yylval.str = strdup(yytext); return PARAM_EXPANSION; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 48 "lexer.l"
+#line 47 "lexer.l"
+{ yylval.str = strdup(yytext); return WORD; }
+	YY_BREAK
+case 29:
+YY_RULE_SETUP
+#line 49 "lexer.l"
 ECHO;
 	YY_BREAK
-#line 911 "lex.yy.c"
+#line 922 "lex.yy.c"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1201,7 +1212,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 51 )
+			if ( yy_current_state >= 54 )
 				yy_c = yy_meta[yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
@@ -1229,11 +1240,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 51 )
+		if ( yy_current_state >= 54 )
 			yy_c = yy_meta[yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 50);
+	yy_is_jam = (yy_current_state == 53);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1909,7 +1920,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 48 "lexer.l"
+#line 49 "lexer.l"
 
 
 #undef YY_NO_INPUT

--- a/log.c
+++ b/log.c
@@ -112,10 +112,10 @@ void log_rotate(void) {
   fclose(log_ctx.file);
   log_ctx.file = NULL;
 
-  for (int i = log_ctx.max_backup_files - 1; i > 0; i--) {
+  for (long i = (long)log_ctx.max_backup_files - 1; i > 0; i--) {
     char old_name[256], new_name[256];
-    snprintf(old_name, sizeof(old_name), "%s.%d", log_ctx.filename, i);
-    snprintf(new_name, sizeof(new_name), "%s.%d", log_ctx.filename, i + 1);
+    snprintf(old_name, sizeof(old_name), "%s.%ld", log_ctx.filename, i);
+    snprintf(new_name, sizeof(new_name), "%s.%ld", log_ctx.filename, i + 1);
     rename(old_name, new_name);
   }
 
@@ -152,45 +152,45 @@ static void format_log_message(char* buffer, size_t buffer_size, const char* for
       fmt++;
       switch (*fmt) {
         case 'Y':
-          ptr += strftime(ptr, end - ptr, "%Y", time_info);
+          ptr += strftime(ptr, (size_t)(end - ptr), "%Y", time_info);
           break;
         case 'M':
-          ptr += strftime(ptr, end - ptr, "%m", time_info);
+          ptr += strftime(ptr, (size_t)(end - ptr), "%m", time_info);
           break;
         case 'd':
-          ptr += strftime(ptr, end - ptr, "%d", time_info);
+          ptr += strftime(ptr, (size_t)(end - ptr), "%d", time_info);
           break;
         case 'H':
-          ptr += strftime(ptr, end - ptr, "%H", time_info);
+          ptr += strftime(ptr, (size_t)(end - ptr), "%H", time_info);
           break;
         case 'I':
-          ptr += strftime(ptr, end - ptr, "%M", time_info);
+          ptr += strftime(ptr, (size_t)(end - ptr), "%M", time_info);
           break;
         case 'S':
-          ptr += strftime(ptr, end - ptr, "%S", time_info);
+          ptr += strftime(ptr, (size_t)(end - ptr), "%S", time_info);
           break;
         case 'L':
-          ptr += snprintf(ptr, end - ptr, "%s", level_str);
+          ptr += snprintf(ptr, (size_t)(end - ptr), "%s", level_str);
           break;
         case 'p':
-          ptr += snprintf(ptr, end - ptr, "%d", getpid());
+          ptr += snprintf(ptr, (size_t)(end - ptr), "%d", getpid());
           break;
         case 'f':
-          ptr += snprintf(ptr, end - ptr, "%s", file);
+          ptr += snprintf(ptr, (size_t)(end - ptr), "%s", file);
           break;
         case 'l':
-          ptr += snprintf(ptr, end - ptr, "%d", line);
+          ptr += snprintf(ptr, (size_t)(end - ptr), "%d", line);
           break;
         case 'n':
-          ptr += snprintf(ptr, end - ptr, "%s", func);
+          ptr += snprintf(ptr, (size_t)(end - ptr), "%s", func);
           break;
         case 'a':
           if (log_ctx.app_name) {
-            ptr += snprintf(ptr, end - ptr, "%s", log_ctx.app_name);
+            ptr += snprintf(ptr, (size_t)(end - ptr), "%s", log_ctx.app_name);
           }
           break;
         case 'm':
-          ptr += snprintf(ptr, end - ptr, "%s", message);
+          ptr += snprintf(ptr, (size_t)(end - ptr), "%s", message);
           break;
         default:
           *ptr++ = '%';

--- a/main.c
+++ b/main.c
@@ -20,7 +20,7 @@
 #define INITIAL_BUFFER_SIZE (1 * 1024)  // 1 KB initial size
 #define MAX_BUFFER_SIZE (100 * 1024 * 1024)  // 100 MB limit
 #define MAX_COMMAND_LENGTH 1000  // Maximum length for a single command
-#define BUFFER_GROWTH_FACTOR 1.5
+#define BUFFER_GROWTH_FACTOR 2
 
 extern int yylex_destroy(void);
 
@@ -40,13 +40,13 @@ static char* get_hostname(void) {
   long host_name_max = sysconf(_SC_HOST_NAME_MAX);
   if (host_name_max == -1)
     host_name_max = _POSIX_HOST_NAME_MAX;
-  hostname = rmalloc(host_name_max + 1);
+  hostname = rmalloc((size_t)host_name_max + 1);
   if (hostname == NULL) {
     perror("Error allocating memory");
     return NULL;
   }
 
-  if (gethostname(hostname, host_name_max + 1) != 0) {
+  if (gethostname(hostname, (size_t)host_name_max + 1) != 0) {
     perror("Error getting hostname");
     rfree(hostname);
     return NULL;
@@ -113,7 +113,7 @@ static char* get_input(size_t* size) {
 
   while (1) {
     size_t remaining = buffer_size - input_length;
-    if (!fgets(buffer + input_length, remaining, stdin)) {
+    if (!fgets(buffer + input_length, (int)remaining, stdin)) {
       if (feof(stdin)) {
         if (input_length == 0) {
           rfree(buffer);
@@ -177,7 +177,7 @@ static int process_command(const char* input) {
   }
 
   if (strcmp(input, "exit") == 0) return 1;
-  parse_and_execute((char*)input);
+  parse_and_execute(input);
   return 0;
 }
 

--- a/main.c
+++ b/main.c
@@ -234,6 +234,7 @@ int main(void) {
 
     yylex_destroy();
   }
+  cleanup_variables();
   log_info("Shell exited");
   log_shutdown();
 

--- a/map.c
+++ b/map.c
@@ -134,8 +134,8 @@ bool map_remove(map* m, const char* key) {
 
       size_t next = (index + 1) % m->capacity;
       while (m->buckets[next].is_occupied) {
-        uint64_t hash = wyhash(m->buckets[next].key, strlen(m->buckets[next].key), 0, _wyp);
-        size_t ideal_pos = hash % m->capacity;
+        uint64_t _hash = wyhash(m->buckets[next].key, strlen(m->buckets[next].key), 0, _wyp);
+        size_t ideal_pos = _hash % m->capacity;
         if ((index < next && (ideal_pos <= index || ideal_pos > next)) || (index > next && (ideal_pos <= index && ideal_pos > next))) {
           m->buckets[index] = m->buckets[next];
           index = next;

--- a/map.c
+++ b/map.c
@@ -9,7 +9,7 @@
 #include "result.h"
 #include "wyhash.h"
 
-map* create_map() {
+map* create_map_with_func(MapFreeFn value_free) {
   map* m = (map*)rmalloc(sizeof(map));
   if (!m) {
     return NULL;
@@ -27,8 +27,12 @@ map* create_map() {
     rfree(m);
     return NULL;
   }
-  m->value_free = rfree;
+  m->value_free = value_free;
   return m;
+}
+
+map* create_map() {
+  return create_map_with_func(rfree);
 }
 
 MapResult resize_map(map* m, size_t new_capacity) {

--- a/memory.c
+++ b/memory.c
@@ -151,12 +151,12 @@ void rfree(void* ptr) {
 
 char *rstrdup(const char *src) {
   size_t len = strlen(src) + 1;
-  char *dst = rmalloc(len);
-  if (dst == NULL) {
+  char* dest = rmalloc(len);
+  if (dest == NULL) {
+    print_error("Memory allocation failed");
     return NULL;
   }
-  memcpy(dst, src, len);
-  return dst;
+  return memcpy(dest, src, len);
 }
 
 char* rstrcat(char* dest, const char* src, size_t dest_size) {

--- a/parser.tab.c
+++ b/parser.tab.c
@@ -484,16 +484,16 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  2
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   80
+#define YYLAST   86
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  22
+#define YYNTOKENS  25
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  13
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  40
+#define YYNRULES  41
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  59
+#define YYNSTATES  64
 
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   274
@@ -514,10 +514,10 @@ static const yytype_int8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
       20,    21,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,    24,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,    22,     2,    23,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -544,9 +544,9 @@ static const yytype_int16 yyrline[] =
 {
        0,    41,    41,    42,    45,    46,    49,    57,    61,    69,
       74,    80,    88,    89,    96,    97,   105,   110,   115,   120,
-     127,   128,   131,   132,   133,   134,   137,   145,   157,   167,
-     175,   185,   193,   201,   209,   217,   225,   234,   242,   250,
-     258
+     127,   128,   131,   132,   133,   134,   137,   145,   157,   165,
+     180,   188,   198,   206,   214,   222,   230,   238,   247,   255,
+     263,   271
 };
 #endif
 
@@ -558,10 +558,10 @@ static const char *const yytname[] =
   "$end", "error", "$undefined", "WORD", "QUOTED_STRING",
   "PARAM_EXPANSION", "PIPE", "LESS", "GREATER", "DGREATER", "LESSAND",
   "GREATAND", "LESSGREAT", "DGREATAND", "AMPERSAND", "SEMICOLON", "AND",
-  "OR", "NEWLINE", "IO_NUMBER", "'('", "')'", "$accept", "input", "line",
-  "command_sequence", "and_or_list", "pipeline", "command",
-  "simple_command", "cmd_prefix", "cmd_suffix", "arg", "cmd_word",
-  "io_redirect", YY_NULLPTR
+  "OR", "NEWLINE", "IO_NUMBER", "'('", "')'", "'['", "']'", "'='",
+  "$accept", "input", "line", "command_sequence", "and_or_list",
+  "pipeline", "command", "simple_command", "cmd_prefix", "cmd_suffix",
+  "arg", "cmd_word", "io_redirect", YY_NULLPTR
 };
 #endif
 
@@ -572,7 +572,7 @@ static const yytype_int16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
      265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-      40,    41
+      40,    41,    91,    93,    61
 };
 # endif
 
@@ -594,8 +594,9 @@ static const yytype_int8 yypact[] =
       45,    51,    37,    30,   -39,    12,    15,    56,   -39,   -39,
       61,    48,   -39,   -39,   -39,   -39,   -39,   -39,   -39,   -39,
       60,    62,    72,   -12,   -39,    30,   -39,    30,    30,    30,
-      48,   -39,   -39,   -39,   -39,    48,   -39,   -39,   -39,   -39,
-     -39,   -39,    15,    56,    56,   -39,    48,   -39,   -39
+      48,   -39,    54,   -39,   -39,    48,   -39,   -39,   -39,   -39,
+     -39,   -39,    15,    56,    56,   -39,    48,    74,   -39,   -39,
+      55,    57,    76,   -39
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -603,19 +604,20 @@ static const yytype_int8 yypact[] =
      means the default is an error.  */
 static const yytype_int8 yydefact[] =
 {
-       2,     0,     1,    29,    30,     0,     0,     0,     0,     0,
+       2,     0,     1,    30,    31,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     3,     5,     6,     9,    12,    14,
-       0,    19,    20,    31,    33,    35,    32,    34,    36,    37,
+       0,    19,    20,    32,    34,    36,    33,    35,    37,    38,
        0,     0,     0,     0,     8,     0,     4,     0,     0,     0,
-      17,    21,    26,    27,    28,    18,    24,    22,    38,    39,
-      40,    15,     7,    10,    11,    13,    16,    25,    23
+      17,    21,    26,    27,    28,    18,    24,    22,    39,    40,
+      41,    15,     7,    10,    11,    13,    16,     0,    25,    23,
+       0,     0,     0,    29
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -39,   -39,   -39,   -39,   -11,    -9,    38,   -39,   -39,    36,
-     -38,    58,   -20
+     -39,   -39,   -39,   -39,   -11,    -9,    43,   -39,   -39,    46,
+     -38,    63,   -20
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
@@ -630,15 +632,15 @@ static const yytype_int8 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int8 yytable[] =
 {
-      41,    47,    33,     2,    37,    38,     3,    57,     4,    51,
-       5,     6,     7,     8,     9,    10,    11,    23,    57,    24,
-      47,    25,    12,    13,    52,    58,    34,    35,    53,    54,
-      36,    37,    38,     3,    26,     4,    58,     5,     6,     7,
+      41,    47,    33,     2,    37,    38,     3,    58,     4,    51,
+       5,     6,     7,     8,     9,    10,    11,    23,    58,    24,
+      47,    25,    12,    13,    52,    59,    34,    35,    53,    54,
+      36,    37,    38,     3,    26,     4,    59,     5,     6,     7,
        8,     9,    10,    11,    30,    31,    32,    27,    28,    12,
       13,    42,    43,    44,    29,     5,     6,     7,     8,     9,
       10,    11,    39,    48,     3,    49,     4,    12,     5,     6,
-       7,     8,     9,    10,    11,    50,    56,    55,    40,     0,
-      12
+       7,     8,     9,    10,    11,    50,    57,    60,    61,    63,
+      12,    62,    55,    40,     0,     0,    56
 };
 
 static const yytype_int8 yycheck[] =
@@ -650,30 +652,31 @@ static const yytype_int8 yycheck[] =
       10,    11,    12,    13,     7,     8,     9,     3,     3,    19,
       20,     3,     4,     5,     3,     7,     8,     9,    10,    11,
       12,    13,     6,     3,     3,     3,     5,    19,     7,     8,
-       9,    10,    11,    12,    13,     3,    40,    39,    20,    -1,
-      19
+       9,    10,    11,    12,    13,     3,    22,     3,    23,     3,
+      19,    24,    39,    20,    -1,    -1,    40
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_int8 yystos[] =
 {
-       0,    23,     0,     3,     5,     7,     8,     9,    10,    11,
-      12,    13,    19,    20,    24,    25,    26,    27,    28,    29,
-      30,    33,    34,     3,     3,     3,     3,     3,     3,     3,
-       7,     8,     9,    26,    14,    15,    18,    16,    17,     6,
-      33,    34,     3,     4,     5,    31,    32,    34,     3,     3,
-       3,    21,    26,    27,    27,    28,    31,    32,    34
+       0,    26,     0,     3,     5,     7,     8,     9,    10,    11,
+      12,    13,    19,    20,    27,    28,    29,    30,    31,    32,
+      33,    36,    37,     3,     3,     3,     3,     3,     3,     3,
+       7,     8,     9,    29,    14,    15,    18,    16,    17,     6,
+      36,    37,     3,     4,     5,    34,    35,    37,     3,     3,
+       3,    21,    29,    30,    30,    31,    34,    22,    35,    37,
+       3,    23,    24,     3
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_int8 yyr1[] =
 {
-       0,    22,    23,    23,    24,    24,    25,    25,    25,    26,
-      26,    26,    27,    27,    28,    28,    29,    29,    29,    29,
-      30,    30,    31,    31,    31,    31,    32,    32,    32,    33,
-      33,    34,    34,    34,    34,    34,    34,    34,    34,    34,
-      34
+       0,    25,    26,    26,    27,    27,    28,    28,    28,    29,
+      29,    29,    30,    30,    31,    31,    32,    32,    32,    32,
+      33,    33,    34,    34,    34,    34,    35,    35,    35,    35,
+      36,    36,    37,    37,    37,    37,    37,    37,    37,    37,
+      37,    37
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
@@ -681,9 +684,9 @@ static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     2,     2,     1,     1,     3,     2,     1,
        3,     3,     1,     3,     1,     3,     3,     2,     2,     1,
-       1,     2,     1,     2,     1,     2,     1,     1,     1,     1,
-       1,     2,     2,     2,     2,     2,     2,     2,     3,     3,
-       3
+       1,     2,     1,     2,     1,     2,     1,     1,     1,     6,
+       1,     1,     2,     2,     2,     2,     2,     2,     2,     3,
+       3,     3
 };
 
 
@@ -1387,7 +1390,7 @@ yyreduce:
                         append_command_list(command_list, (yyvsp[0].cmd_list));
                     }
                 }
-#line 1391 "parser.tab.c"
+#line 1394 "parser.tab.c"
     break;
 
   case 7:
@@ -1395,7 +1398,7 @@ yyreduce:
                 {
                     append_command_list(command_list, (yyvsp[0].cmd_list));
                 }
-#line 1399 "parser.tab.c"
+#line 1402 "parser.tab.c"
     break;
 
   case 8:
@@ -1405,7 +1408,7 @@ yyreduce:
                         set_command_background(command_list->tail);
                     }
                 }
-#line 1409 "parser.tab.c"
+#line 1412 "parser.tab.c"
     break;
 
   case 9:
@@ -1414,7 +1417,7 @@ yyreduce:
                 (yyval.cmd_list) = create_command_list();
                 add_command((yyval.cmd_list), (yyvsp[0].cmd));
             }
-#line 1418 "parser.tab.c"
+#line 1421 "parser.tab.c"
     break;
 
   case 10:
@@ -1424,7 +1427,7 @@ yyreduce:
                 add_command((yyvsp[-2].cmd_list), (yyvsp[0].cmd));
                 (yyval.cmd_list) = (yyvsp[-2].cmd_list);
             }
-#line 1428 "parser.tab.c"
+#line 1431 "parser.tab.c"
     break;
 
   case 11:
@@ -1434,7 +1437,7 @@ yyreduce:
                 add_command((yyvsp[-2].cmd_list), (yyvsp[0].cmd));
                 (yyval.cmd_list) = (yyvsp[-2].cmd_list);
             }
-#line 1438 "parser.tab.c"
+#line 1441 "parser.tab.c"
     break;
 
   case 13:
@@ -1443,7 +1446,7 @@ yyreduce:
             add_pipeline((yyvsp[-2].cmd), (yyvsp[0].cmd));
             (yyval.cmd) = (yyvsp[-2].cmd);
         }
-#line 1447 "parser.tab.c"
+#line 1450 "parser.tab.c"
     break;
 
   case 15:
@@ -1453,7 +1456,7 @@ yyreduce:
             (yyval.cmd)->is_subcommand = 1;
             // $$->subcommand_list = $2;
        }
-#line 1457 "parser.tab.c"
+#line 1460 "parser.tab.c"
     break;
 
   case 16:
@@ -1462,7 +1465,7 @@ yyreduce:
                    (yyval.cmd) = current_command;
                    current_command = NULL;
                }
-#line 1466 "parser.tab.c"
+#line 1469 "parser.tab.c"
     break;
 
   case 17:
@@ -1471,7 +1474,7 @@ yyreduce:
                    (yyval.cmd) = current_command;
                    current_command = NULL;
                }
-#line 1475 "parser.tab.c"
+#line 1478 "parser.tab.c"
     break;
 
   case 18:
@@ -1480,7 +1483,7 @@ yyreduce:
                    (yyval.cmd) = current_command;
                    current_command = NULL;
                }
-#line 1484 "parser.tab.c"
+#line 1487 "parser.tab.c"
     break;
 
   case 19:
@@ -1489,7 +1492,7 @@ yyreduce:
                    (yyval.cmd) = current_command;
                    current_command = NULL;
                }
-#line 1493 "parser.tab.c"
+#line 1496 "parser.tab.c"
     break;
 
   case 26:
@@ -1501,7 +1504,7 @@ yyreduce:
        add_argument(current_command, (yyvsp[0].str));
        rfree((yyvsp[0].str));
    }
-#line 1505 "parser.tab.c"
+#line 1508 "parser.tab.c"
     break;
 
   case 27:
@@ -1517,7 +1520,7 @@ yyreduce:
        rfree(unquoted);
        rfree((yyvsp[0].str));
    }
-#line 1521 "parser.tab.c"
+#line 1524 "parser.tab.c"
     break;
 
   case 28:
@@ -1529,23 +1532,28 @@ yyreduce:
        add_argument(current_command, (yyvsp[0].str));
        rfree((yyvsp[0].str));
    }
-#line 1533 "parser.tab.c"
+#line 1536 "parser.tab.c"
     break;
 
   case 29:
-#line 168 "parser.y"
-        {
-            if (current_command == NULL) {
-                current_command = create_command();
-            }
-            add_argument(current_command, (yyvsp[0].str));
-            rfree((yyvsp[0].str));
-        }
-#line 1545 "parser.tab.c"
+#line 166 "parser.y"
+   {
+       if (current_command == NULL) {
+           current_command = create_command();
+       }
+       char* array_assignment = malloc(strlen((yyvsp[-5].str)) + strlen((yyvsp[-3].str)) + strlen((yyvsp[0].str)) + 6);
+       sprintf(array_assignment, "%s[%s]=%s", (yyvsp[-5].str), (yyvsp[-3].str), (yyvsp[0].str));
+       add_argument(current_command, array_assignment);
+       free(array_assignment);
+       rfree((yyvsp[-5].str));
+       rfree((yyvsp[-3].str));
+       rfree((yyvsp[0].str));
+   }
+#line 1553 "parser.tab.c"
     break;
 
   case 30:
-#line 176 "parser.y"
+#line 181 "parser.y"
         {
             if (current_command == NULL) {
                 current_command = create_command();
@@ -1553,11 +1561,23 @@ yyreduce:
             add_argument(current_command, (yyvsp[0].str));
             rfree((yyvsp[0].str));
         }
-#line 1557 "parser.tab.c"
+#line 1565 "parser.tab.c"
     break;
 
   case 31:
-#line 186 "parser.y"
+#line 189 "parser.y"
+        {
+            if (current_command == NULL) {
+                current_command = create_command();
+            }
+            add_argument(current_command, (yyvsp[0].str));
+            rfree((yyvsp[0].str));
+        }
+#line 1577 "parser.tab.c"
+    break;
+
+  case 32:
+#line 199 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1565,11 +1585,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_INPUT, STDIN_FILENO, (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1569 "parser.tab.c"
+#line 1589 "parser.tab.c"
     break;
 
-  case 32:
-#line 194 "parser.y"
+  case 33:
+#line 207 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1577,11 +1597,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_INPUT_DUP, STDIN_FILENO, (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1581 "parser.tab.c"
+#line 1601 "parser.tab.c"
     break;
 
-  case 33:
-#line 202 "parser.y"
+  case 34:
+#line 215 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1589,11 +1609,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_OUTPUT, STDOUT_FILENO, (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1593 "parser.tab.c"
+#line 1613 "parser.tab.c"
     break;
 
-  case 34:
-#line 210 "parser.y"
+  case 35:
+#line 223 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1601,11 +1621,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_OUTPUT_DUP, STDOUT_FILENO, (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1605 "parser.tab.c"
+#line 1625 "parser.tab.c"
     break;
 
-  case 35:
-#line 218 "parser.y"
+  case 36:
+#line 231 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1613,11 +1633,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_APPEND, STDOUT_FILENO, (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1617 "parser.tab.c"
+#line 1637 "parser.tab.c"
     break;
 
-  case 36:
-#line 226 "parser.y"
+  case 37:
+#line 239 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1626,11 +1646,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_OUTPUT, STDOUT_FILENO, (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1630 "parser.tab.c"
+#line 1650 "parser.tab.c"
     break;
 
-  case 37:
-#line 235 "parser.y"
+  case 38:
+#line 248 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1638,11 +1658,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_APPEND_DUP, STDOUT_FILENO, (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1642 "parser.tab.c"
+#line 1662 "parser.tab.c"
     break;
 
-  case 38:
-#line 243 "parser.y"
+  case 39:
+#line 256 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1650,11 +1670,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_INPUT, (yyvsp[-2].num), (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1654 "parser.tab.c"
+#line 1674 "parser.tab.c"
     break;
 
-  case 39:
-#line 251 "parser.y"
+  case 40:
+#line 264 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1662,11 +1682,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_OUTPUT, (yyvsp[-2].num), (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1666 "parser.tab.c"
+#line 1686 "parser.tab.c"
     break;
 
-  case 40:
-#line 259 "parser.y"
+  case 41:
+#line 272 "parser.y"
            {
                if (current_command == NULL) {
                    current_command = create_command();
@@ -1674,11 +1694,11 @@ yyreduce:
                add_redirect(current_command, REDIRECT_APPEND, (yyvsp[-2].num), (yyvsp[0].str));
                rfree((yyvsp[0].str));
            }
-#line 1678 "parser.tab.c"
+#line 1698 "parser.tab.c"
     break;
 
 
-#line 1682 "parser.tab.c"
+#line 1702 "parser.tab.c"
 
       default: break;
     }
@@ -1910,7 +1930,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 268 "parser.y"
+#line 281 "parser.y"
 
 
 void yyerror(const char* s) {

--- a/pipeline.c
+++ b/pipeline.c
@@ -13,7 +13,10 @@ int execute_pipeline(Command* first_cmd) {
   int prev_fd = -1;
 
   while (cmd != NULL && cmd->pipline_next) {
-    pipe(pipefd);
+    if (pipe(pipefd) == -1) {
+      perror("pipe failed");
+      return -1;
+    }
     pid = fork();
 
     if (pid == 0) {

--- a/string.c
+++ b/string.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdbool.h>
 #include "rstring.h"
 #include "memory.h"
 
@@ -17,6 +18,126 @@ char* remove_quotes(const char* str) {
   }
     
   return rstrdup(str);
+}
+
+char* str_replace(const char* src, const char* old, const char* new, bool replace_all) {
+  char* result;
+  size_t i, cnt = 0;
+  size_t newlen = strlen(new);
+  size_t oldlen = strlen(old);
+
+  for (i = 0; src[i] != '\0'; i++) {
+    if (strstr(&src[i], old) == &src[i]) {
+      cnt++;
+      i += oldlen - 1;
+      if (!replace_all) break;
+    }
+  }
+
+  result = rmalloc(i + cnt * (newlen - oldlen) + 1);
+
+  i = 0;
+  while (*src) {
+    if (strstr(src, old) == src) {
+      strcpy(&result[i], new);
+      i += newlen;
+      src += oldlen;
+      if (!replace_all) {
+        strcat(result, src);
+        return result;
+      }
+    } else {
+      result[i++] = *src++;
+    }
+  }
+  result[i] = '\0';
+  return result;
+}
+
+bool match_pattern(const char* str, const char* pattern) {
+  const char* s = str;
+  const char* p = pattern;
+  
+  while (*s && *p) {
+    if (*p == '*') {
+      p++;
+      if (*p == '\0') return true;
+      while (*s) {
+        if (match_pattern(s, p)) return true;
+        s++;
+      }
+      return false;
+    } else if (*p == '?' || *p == *s) {
+      s++;
+      p++;
+    } else {
+      return false;
+    }
+  }
+  
+  while (*p == '*') p++;
+  return *p == '\0';
+}
+
+char* remove_prefix(const char* value, const char* pattern, bool is_longest_match) {
+  size_t value_len = strlen(value);
+  const char* best_match = NULL;
+
+  if (is_longest_match) {
+    for (size_t i = 0; i < value_len; i++) {
+      if (match_pattern(value + i, pattern))
+        best_match = strchr(value + i, '.');
+    }
+  } else {
+    for (size_t i = 0; i < value_len; i++) {
+      if (match_pattern(value + i, pattern)) {
+        best_match = strchr(value + i, '.');
+        break;
+      }
+    }
+  }
+
+  if (best_match != NULL) {
+    return strdup(best_match);
+  }
+
+  return strdup(value);
+}
+
+char* remove_suffix(const char* str, const char* suffix, bool greedy) {
+  size_t suffix_len = strlen(suffix);
+  size_t str_len = strlen(str);
+  char* result = rstrdup(str);
+
+  if (greedy) {
+    while (str_len >= suffix_len && strcmp(result + str_len - suffix_len, suffix) == 0) {
+      result[str_len - suffix_len] = '\0';
+      str_len -= suffix_len;
+    }
+  } else if (str_len >= suffix_len && strcmp(result + str_len - suffix_len, suffix) == 0) {
+    result[str_len - suffix_len] = '\0';
+  }
+
+  return result;
+}
+
+char* dynstrcpy(char** dest, size_t* dest_size, size_t* dest_len, const char* src) {
+  size_t src_len = strlen(src);
+  size_t new_len = *dest_len + src_len;
+
+  if (new_len >= *dest_size) {
+    size_t new_size = *dest_size;
+    while (new_size <= new_len) {
+      new_size *= 2;
+    }
+    *dest = rrealloc(*dest, new_size);
+    *dest_size = new_size;
+  }
+
+  strcpy(*dest + *dest_len, src);
+  *dest_len = new_len;
+
+  return *dest;
 }
 
 void ltrim(char* str) {

--- a/string.c
+++ b/string.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include "rstring.h"
 #include "memory.h"
 
@@ -16,4 +17,24 @@ char* remove_quotes(const char* str) {
   }
     
   return rstrdup(str);
+}
+
+void ltrim(char* str) {
+  if (str == NULL) return;
+  
+  while (*str && isspace(*str)) str++;
+  memmove(str, str + strspn(str, " \t\r\n"), 1 + strlen(str + strspn(str, " \t\r\n")));
+}
+
+void rtrim(char* str) {
+  if (str == NULL) return;
+  
+  size_t len = strlen(str);
+  while (len > 0 && isspace(str[len - 1])) len--;
+  str[len] = '\0';
+}
+
+void trim(char* str) {
+  ltrim(str);
+  rtrim(str);
 }

--- a/variable.c
+++ b/variable.c
@@ -744,3 +744,13 @@ void free_va_value(va_value_t* value) {
       break;
   }
 }
+
+void free_variable(Variable* var) {
+  rfree(var->name);
+  rfree(var->value);
+  free_va_value(&var->data);
+}
+
+void cleanup_variables() {
+  free_variable_table(variable_table);
+}

--- a/variable.c
+++ b/variable.c
@@ -36,78 +36,83 @@ void free_variable_table(VariableTable* table) {
   rfree(table);
 }
 
-static void expand_table(VariableTable* table) {
-  table->capacity *= 2;
-  table->variables = rrealloc(table->variables, table->capacity * sizeof(Variable));
-}
-
-Variable* set_variable(VariableTable* table, const char* name, const char* value, VariableType type, bool readonly) {
-  for (int i = 0; i < table->size; i++) {
-    if (strcmp(table->variables[i].name, name) == 0) {
-      Variable* var = resolve_nameref(&table->variables[i]);
-      if (var == NULL) {
-        print_error("Failed to resolve nameref");
-        return NULL;
-      }
-
-      if (is_variable_flag_set(&var->flags, VarFlag_ReadOnly)) {
-        print_error("Cannot modify readonly variable");
-        return NULL;
-      }
-      rfree(var->value);
-      var->value = rstrdup(value);
-      var->type = type;
-      if (readonly) set_variable_flag(&var->flags, VarFlag_ReadOnly);
-
-      switch (type) {
-      case VAR_STRING:
-        var->data._str = remove_quotes(value);
-        break;
-      case VAR_INTEGER:
-        StrconvResult result = ratoll(value, &var->data._number);
-        if (result.is_err) {
-          print_error("Failed to convert string to integer");
-          return NULL;
-        }
-        break;
-      case VAR_ARRAY:
-        if (var->data._array.data) array_free(&var->data._array);
-        parse_and_set_array(variable_table, name, value);
-        break;
-      case VAR_ASSOCIATIVE_ARRAY:
-        if (var->data._map == NULL) {
-          var->data._map = create_map();
-        }
-        break;
-      default:
-        break;
-      }
-      
-      return var;
-    }
-  }
-
+Variable* create_new_variable(VariableTable* table, const char* name, VariableType type) {
   if (table->size == table->capacity) {
-    expand_table(table);
+    table->capacity *= 2;
+    table->variables = rrealloc(table->variables, (size_t)(table->capacity * (int)sizeof(Variable)));
   }
 
   Variable* var = &table->variables[table->size++];
   var->name = rstrdup(name);
-  var->value = rstrdup(value);
+  var->value = NULL;
   var->type = type;
   var->flags = 0;
   var->array_size = 0;
+
+  memset(&var->data, 0, sizeof(va_value_t));
+  var->data.type = type;
   
-  if (type == VAR_INTEGER) {
-    var->data._number = atoi(value);
-  } else if (type == VAR_ASSOCIATIVE_ARRAY) {
-    var->data._map = create_map();
-  } else if (type == VAR_ARRAY) {
-    var->data._array = create_array(sizeof(va_value_t));
+  switch (type) {
+    case VAR_STRING:
+      var->data._str = NULL;
+      break;
+    case VAR_INTEGER:
+      var->data._number = 0;
+      break;
+    case VAR_ASSOCIATIVE_ARRAY:
+      var->data._map = create_map();
+      break;
+    case VAR_ARRAY:
+      var->data._array = create_array(sizeof(va_value_t));
+      break;
+    default:
+      break;
   }
 
-  if (readonly) set_variable_flag(&var->flags, VarFlag_ReadOnly);
+  return var;
+}
 
+Variable* set_variable(VariableTable* table, const char* name, const char* value, VariableType type, bool readonly) {
+  Variable* var = get_variable(table, name);
+  if (var == NULL) {
+    var = create_new_variable(table, name, type);
+  } else {
+    rfree(var->value);
+    free_va_value(&var->data);
+  }
+  if (is_variable_flag_set(&var->flags, VarFlag_ReadOnly)) {
+    print_error("Cannot modify readonly variable");
+    return NULL;
+  }
+
+  var->value = rstrdup(value);
+  var->type = type;
+  var->data.type = type;
+
+  switch (type) {
+    case VAR_STRING:
+      var->data._str = rstrdup(value);
+      break;
+    case VAR_INTEGER:
+      StrconvResult result = ratoll(value, &var->data._number);
+      if (result.is_err) {
+        print_error("Failed to convert string to integer");
+        return NULL;
+      }
+      break;
+    case VAR_ARRAY:
+      if (var->data._array.data) array_free(&var->data._array);
+      parse_and_set_array(variable_table, name, value);
+      break;
+    case VAR_ASSOCIATIVE_ARRAY:
+      if (var->data._map == NULL) {
+        var->data._map = create_map();
+      }
+      break;
+    default:
+      break;
+  }
+  if (readonly) set_variable_flag(&var->flags, VarFlag_ReadOnly);
   return var;
 }
 
@@ -115,8 +120,14 @@ Variable* get_variable(VariableTable* table, const char* name) {
   for (int i = 0; i < table->size; i++) {
     if (strcmp(table->variables[i].name, name) == 0) {
       Variable* var = &table->variables[i];
-      if (var->type == VAR_NAMEREF) 
-        return resolve_nameref(var);
+      if (var->type == VAR_NAMEREF) {
+        Variable* resolved = resolve_nameref(var);
+        if (resolved == NULL) {
+          print_error("Failed to resolve nameref");
+          return NULL;
+        }
+        return resolved;
+      }
       return var;
     }
   }
@@ -133,131 +144,208 @@ void unset_variable(VariableTable* table, const char* name) {
       rfree(table->variables[i].name);
       rfree(table->variables[i].value);
       free_va_value(&table->variables[i].data);
-      memmove(&table->variables[i], &table->variables[i + 1], (table->size - i - 1) * sizeof(Variable));
+      memmove(&table->variables[i], &table->variables[i + 1], (size_t)((table->size - i - 1) * (int)sizeof(Variable)));
       table->size--;
       return;
     }
   }
 }
 
-static char* str_replace(const char* src, const char* old, const char* new, bool replace_all) {
-  char* result;
-  int i, cnt = 0;
-  int newlen = strlen(new);
-  int oldlen = strlen(old);
+void parse_and_set_array(VariableTable* table, const char* name, const char* value) {
+  char* trimmed_value = rstrdup(value + 1);
+  trimmed_value[strlen(trimmed_value) - 1] = '\0';
+  Variable* var = create_new_variable(table, name, VAR_ARRAY);
 
-  for (i = 0; src[i] != '\0'; i++) {
-    if (strstr(&src[i], old) == &src[i]) {
-      cnt++;
-      i += oldlen - 1;
-      if (!replace_all) break;
-    }
+  char* token;
+  char* rest = trimmed_value;
+
+  while ((token = strtok_r(rest, " ", &rest)) != NULL) {
+    VariableType type = parse_variable_type(token);
+    va_value_t _value = string_to_va_value(token, type);
+    array_push(&var->data._array, &_value);
   }
 
-  result = rmalloc(i + cnt * (newlen - oldlen) + 1);
+  rfree(trimmed_value);
+}
 
-  i = 0;
-  while (*src) {
-    if (strstr(src, old) == src) {
-      strcpy(&result[i], new);
-      i += newlen;
-      src += oldlen;
-      if (!replace_all) {
-        strcat(result, src);
-        return result;
+void array_set_element(VariableTable* table, const char* name, size_t index, const char* value) {
+  Variable* var = get_variable(table, name);
+  if (var == NULL || var->type != VAR_ARRAY) {
+    print_error("Variable is not an array");
+    return;
+  }
+
+  if (index >= var->data._array.size) {
+    print_error("Index out of bounds");
+    return;
+  }
+
+  VariableType type = parse_variable_type(value);
+  va_value_t new_value = string_to_va_value(value, type);
+  array_index_set(&var->data._array, index, &new_value);
+}
+
+bool do_not_expand_this_builtin(const char* name) {
+  char* do_not_expand[] = {"readonly", "set"};
+  for (int i = 0; (unsigned long)i < sizeof(do_not_expand) / sizeof(char*); i++) {
+    if (strcmp(name, do_not_expand[i]) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+VariableType parse_variable_type(const char* value) {
+  if (value == NULL || *value == '\0')
+    return VAR_STRING;
+  while (isspace(*value)) value++;
+  const char* end = value + strlen(value) - 1;
+  while (end > value && isspace(*end)) end--;
+  end++;
+  if ((value[0] == '"' && end[-1] == '"') || (value[0] == '\'' && end[-1] == '\''))
+    return VAR_STRING;
+  char* endptr;
+  strtol(value, &endptr, 10);
+  if (*endptr == '\0')
+    return VAR_INTEGER;
+  if (value[0] == '(' && end[-1] == ')')
+    return VAR_ARRAY;
+  if (value[0] == '{' && end[-1] == '}')
+    return VAR_ASSOCIATIVE_ARRAY;
+  return VAR_STRING;
+}
+
+Variable* resolve_nameref(Variable* var) {
+  if (var == NULL || var->type != VAR_NAMEREF) {
+    return var;
+  }
+  
+  Variable* resolved = NULL;
+  int depth = 0;
+  while (resolved != NULL && resolved->type == VAR_NAMEREF) {
+    if (depth++ > 100) {
+      print_error("Too many levels of indirection");
+      return NULL;
+    }
+    resolved = get_variable(variable_table, resolved->data._str);
+    if (resolved == NULL) {
+      print_error("Variable not found");
+      return NULL;
+    }
+  }
+  return resolved;
+}
+
+void set_associative_array_variable(VariableTable* table, const char* name, const char* key, const char* value) {
+  Variable* var = get_variable(table, name);
+  if (var == NULL) var = create_new_variable(table, name, VAR_ASSOCIATIVE_ARRAY);
+
+  if (var->type != VAR_ASSOCIATIVE_ARRAY) {
+    print_error("Variable is not an associative array");
+    return;
+  }
+
+  va_value_t new_value = string_to_va_value(value, VAR_STRING);
+  map_insert(var->data._map, key, &new_value, sizeof(va_value_t));
+}
+
+char* va_value_to_string(const va_value_t* value) {
+  char* result = NULL;
+  switch (value->type) {
+    case VAR_STRING:
+      result = rstrdup(value->_str);
+      break;
+    case VAR_INTEGER:
+      result = rmalloc(32);
+      snprintf(result, 32, "%lld", value->_number);
+      break;
+    case VAR_ARRAY:
+      size_t total_length = 2;
+      for (size_t i = 0; i < value->_array.size; ++i) {
+        va_value_t element = *(va_value_t*)array_checked_get(value->_array, i);
+        char* element_str = va_value_to_string(&element);
+        total_length += strlen(element_str) + 1;
+        free(element_str);
       }
-    } else {
-      result[i++] = *src++;
-    }
+      result = rmalloc(total_length);
+      strcpy(result, "(");
+      for (size_t i = 0; i < value->_array.size; ++i) {
+        va_value_t element = *(va_value_t*)array_checked_get(value->_array, i);
+        char* element_str = va_value_to_string(&element);
+        strcat(result, element_str);
+        if (i < value->_array.size - 1)
+          strcat(result, " ");
+        free(element_str);
+      }
+      strcat(result, ")");
+      break;
+    case VAR_ASSOCIATIVE_ARRAY:
+      break;
+    default:
+      result = rstrdup("");
+      break;
   }
-  result[i] = '\0';
   return result;
 }
 
-bool match_pattern(const char* str, const char* pattern) {
-  const char* s = str;
-  const char* p = pattern;
-  
-  while (*s && *p) {
-    if (*p == '*') {
-      p++;
-      if (*p == '\0') return true;
-      while (*s) {
-        if (match_pattern(s, p)) return true;
-        s++;
+va_value_t string_to_va_value(const char* str, VariableType type) {
+  va_value_t result;
+  result.type = type;
+  switch (type) {
+    case VAR_STRING:
+      result._str = remove_quotes(str);
+      break;
+    case VAR_INTEGER:
+      result._number = atoll(str);
+      break;
+    case VAR_ARRAY:
+      result._array = create_array(sizeof(va_value_t));
+      char* token;
+      char* rest = rstrdup(str + 1);
+      rest[strlen(rest) - 1] = '\0';
+      while ((token = strtok_r(rest, " ", &rest))) {
+        VariableType _type = parse_variable_type(token);
+        va_value_t value = string_to_va_value(token, _type);
+        array_push(&result._array, &value);
       }
-      return false;
-    } else if (*p == '?' || *p == *s) {
-      s++;
-      p++;
-    } else {
-      return false;
-    }
+      rfree(rest);
+      break;
+    case VAR_ASSOCIATIVE_ARRAY:
+      result._map = create_map();
+      break;
+    default:
+      result.type = VAR_STRING;
+      result._str = rstrdup("");
+      break;
   }
-  
-  while (*p == '*') p++;
-  return *p == '\0';
-}
-
-char* remove_prefix(const char* value, const char* pattern, bool is_longest_match) {
-  int value_len = strlen(value);
-  const char* best_match = NULL;
-
-  if (is_longest_match) {
-    for (int i = 0; i < value_len; i++) {
-      if (match_pattern(value + i, pattern))
-        best_match = strchr(value + i, '.');
-    }
-  } else {
-    for (int i = 0; i < value_len; i++) {
-      if (match_pattern(value + i, pattern)) {
-        best_match = strchr(value + i, '.');
-        break;
-      }
-    }
-  }
-
-  if (best_match != NULL) {
-    return strdup(best_match);
-  }
-
-  return strdup(value);
-}
-
-static char* remove_suffix(const char* str, const char* suffix, bool greedy) {
-  int suffix_len = strlen(suffix);
-  int str_len = strlen(str);
-  char* result = rstrdup(str);
-
-  if (greedy) {
-    while (str_len >= suffix_len && strcmp(result + str_len - suffix_len, suffix) == 0) {
-      result[str_len - suffix_len] = '\0';
-      str_len -= suffix_len;
-    }
-  } else if (str_len >= suffix_len && strcmp(result + str_len - suffix_len, suffix) == 0) {
-    result[str_len - suffix_len] = '\0';
-  }
-
   return result;
 }
 
-char* dynstrcpy(char** dest, size_t* dest_size, size_t* dest_len, const char* src) {
-  size_t src_len = strlen(src);
-  size_t new_len = *dest_len + src_len;
-
-  if (new_len >= *dest_size) {
-    size_t new_size = *dest_size;
-    while (new_size <= new_len) {
-      new_size *= 2;
-    }
-    *dest = rrealloc(*dest, new_size);
-    *dest_size = new_size;
+void free_va_value(va_value_t* value) {
+  switch (value->type) {
+    case VAR_STRING:
+      rfree(value->_str);
+      break;
+    case VAR_ARRAY:
+      array_free(&value->_array);
+      break;
+    case VAR_ASSOCIATIVE_ARRAY:
+      map_free(value->_map);
+      break;
+    default:
+      break;
   }
+}
 
-  strcpy(*dest + *dest_len, src);
-  *dest_len = new_len;
+void free_variable(Variable* var) {
+  if (var == NULL) return;
+  rfree(var->name);
+  rfree(var->value);
+  free_va_value(&var->data);
+}
 
-  return *dest;
+void cleanup_variables() {
+  free_variable_table(variable_table);
 }
 
 char* expand_variables(VariableTable* table, const char* input) {
@@ -271,7 +359,7 @@ char* expand_variables(VariableTable* table, const char* input) {
       if (*(p + 1) == '{') {
         const char* end = strchr(p + 2, '}');
         if (end) {
-          size_t var_name_len = end - (p + 2);
+          size_t var_name_len = (size_t)(end - (p + 2));
           char* var_name = rmalloc(var_name_len + 1);
           strncpy(var_name, p + 2, var_name_len);
           var_name[var_name_len] = '\0';
@@ -311,7 +399,7 @@ char* expand_variables(VariableTable* table, const char* input) {
                 return NULL;
               }
               if (index >= 0 && index < (long long)var->data._array.size) {
-                va_value_t* value = array_checked_get(var->data._array, index);
+                va_value_t* value = array_checked_get(var->data._array, (size_t)index);
                 char* str_value = va_value_to_string(value);
                 dynstrcpy(&result, &result_size, &result_len, str_value);
                 rfree(str_value);
@@ -319,12 +407,12 @@ char* expand_variables(VariableTable* table, const char* input) {
             }
           } else if (hash) {
             if (*var_name == '#') {
-              const char* var_name = hash + 1;
-              Variable* var = get_variable(table, var_name);
+              const char* vname = hash + 1;
+              Variable* var = get_variable(table, vname);
               if (var) {
-                int length = strlen(var->value);
+                size_t length = strlen(var->value);
                 char length_str[20];
-                snprintf(length_str, sizeof(length_str), "%d", length);
+                snprintf(length_str, sizeof(length_str), "%ld", length);
                 dynstrcpy(&result, &result_size, &result_len, length_str);
               }
             } else {
@@ -350,7 +438,7 @@ char* expand_variables(VariableTable* table, const char* input) {
             }
           } else if (exclamation) {
             char* indirect_var_name = var_name + 1;
-            int indirect_var_name_len = strlen(indirect_var_name);
+            size_t indirect_var_name_len = strlen(indirect_var_name);
             if (indirect_var_name[indirect_var_name_len - 1] == '*' || indirect_var_name[indirect_var_name_len - 1] == '@') {
               indirect_var_name[indirect_var_name_len - 1] = '\0';
               for (int i = 0; i < table->size; i++) {
@@ -381,14 +469,14 @@ char* expand_variables(VariableTable* table, const char* input) {
               if (*pattern == '\0') {
                 for (char* c = value; *c; c++) {
                   if (convert_all || c == value) {
-                    *c = toupper(*c);
+                    *c = (char)toupper(*c);
                   }
                 }
               } else {
                 for (char* c = value; *c; c++) {
                   if (strchr(pattern, *c) != NULL) {
                     if (convert_all || c == value) {
-                      *c = toupper(*c);
+                      *c = (char)toupper(*c);
                     }
                   }
                 }
@@ -403,10 +491,10 @@ char* expand_variables(VariableTable* table, const char* input) {
               char* value = rstrdup(var->value);
               if (*(comma + 1) == ',') {
                 for (char* c = value; *c; c++) {
-                  *c = tolower(*c);
+                  *c = (char)tolower(*c);
                 }
               } else {
-                *value = tolower(*value);
+                *value = (char)tolower(*value);
               }
               dynstrcpy(&result, &result_size, &result_len, value);
               rfree(value);
@@ -419,17 +507,17 @@ char* expand_variables(VariableTable* table, const char* input) {
               long offset = strtol(colon + 1, &endptr, 10);
               char* length_str = (*endptr == ':') ? endptr + 1 : NULL;
 
-              int var_len = strlen(var->value);
+              size_t var_len = strlen(var->value);
               
               if (offset < 0) {
-                offset = var_len + offset;
+                offset = (long)var_len + offset;
               }
 
               if (length_str) {
                 long length = strtol(length_str, NULL, 10);
                 if (offset >= 0 && length > 0 && offset + length <= (long)var_len) {
-                  char* temp = rmalloc(length + 1);
-                  strncpy(temp, var->value + offset, length);
+                  char* temp = rmalloc((size_t)length + 1);
+                  strncpy(temp, var->value + offset, (size_t)length);
                   temp[length] = '\0';
                   dynstrcpy(&result, &result_size, &result_len, temp);
                   rfree(temp);
@@ -558,7 +646,7 @@ char* expand_variables(VariableTable* table, const char* input) {
         const char* var_end = var_start;
         while (isalnum(*var_end) || *var_end == '_') var_end++;
         
-        size_t var_name_len = var_end - var_start;
+        size_t var_name_len = (size_t)(var_end - var_start);
         char* var_name = rmalloc(var_name_len + 1);
         strncpy(var_name, var_start, var_name_len);
         var_name[var_name_len] = '\0';
@@ -580,273 +668,6 @@ char* expand_variables(VariableTable* table, const char* input) {
   return result;
 }
 
-void parse_and_set_array(VariableTable* table, const char* name, const char* value) {
-  char* trimmed_value = rstrdup(value + 1);
-  trimmed_value[strlen(trimmed_value) - 1] = '\0';
-  Variable* var = set_variable(table, name, "", VAR_ARRAY, false);
-
-  char* token;
-  char* rest = trimmed_value;
-
-  while ((token = strtok_r(rest, " ", &rest))) {
-    VariableType type = parse_variable_type(token);
-    va_value_t value = string_to_va_value(token, type);
-    array_push(&var->data._array, &value);
-  }
-
-  rfree(trimmed_value);
-}
-
-void array_add_element(VariableTable* table, const char* name, const char* value) {
-  Variable* var = get_variable(table, name);
-  if (var == NULL || var->type != VAR_ARRAY) {
-    print_error("Variable is not an array");
-    return;
-  }
-
-  VariableType type = parse_variable_type(value);
-  va_value_t new_value = string_to_va_value(value, type);
-  array_push(&var->data._array, &new_value);
-}
-
-void array_set_element(VariableTable* table, const char* name, size_t index, const char* value) {
-  Variable* var = get_variable(table, name);
-  if (var == NULL || var->type != VAR_ARRAY) {
-    print_error("Variable is not an array");
-    return;
-  }
-
-  if (index >= var->data._array.size) {
-    print_error("Index out of bounds");
-    return;
-  }
-
-  VariableType type = parse_variable_type(value);
-  va_value_t new_value = string_to_va_value(value, type);
-  array_index_set(&var->data._array, index, &new_value);
-}
-
-char* array_get_element(VariableTable* table, const char* name, size_t index) {
-  Variable* var = get_variable(table, name);
-  if (var == NULL || var->type != VAR_ARRAY) {
-    print_error("Variable is not an array");
-    return NULL;
-  }
-
-  if (index >= var->data._array.size) {
-    print_error("Index out of bounds");
-    return NULL;
-  }
-
-  va_value_t* value = (va_value_t*)array_checked_get(var->data._array, index);
-  return va_value_to_string(value);
-}
-
-void array_print(VariableTable* table, const char* name) {
-  Variable* var = get_variable(table, name);
-  if (var == NULL || var->type != VAR_ARRAY) {
-    print_error("Variable is not an array");
-    return;
-  }
-
-  printf("%s=(", name);
-  for (size_t i = 0; i < var->data._array.size; i++) {
-    va_value_t* value = (va_value_t*)array_get(var->data._array, i);
-    char* str_value = va_value_to_string(value);
-    printf("%s", str_value);
-    if (i < var->data._array.size - 1)
-      printf(" ");
-    rfree(str_value);
-  }
-  printf(")\n");
-}
-
-void export_variable(VariableTable* table, const char* name) {
-  Variable* var = get_variable(table, name);
-  if (var) {
-    setenv(name, var->value, 1);
-  } else {
-    print_error("Variable not found");
-  }
-}
-
-void set_array_variable(VariableTable* table, const char* name, char** values, int size) {
-  Variable* var = get_variable(table, name);
-  if (var) {
-    if (is_variable_flag_set(&var->flags, VarFlag_ReadOnly)) {
-      print_error("Cannot modify readonly variable");
-      return;
-    }
-    if (var->type == VAR_ARRAY) {
-      array_free(&var->data._array);
-    } else if (var->type == VAR_ASSOCIATIVE_ARRAY) {
-      map_free(var->data._map);
-    }
-  } else {
-    var = set_variable(table, name, "", VAR_STRING, false);
-  }
-
-  var->type = VAR_ARRAY;
-  var->data._array = create_array(size);
-  var->array_size = size;
-
-  for (int i = 0; i < size; i++) {
-    VariableType type = parse_variable_type(values[i]);
-    va_value_t value = string_to_va_value(values[i], type);
-    array_push(&var->data._array, &value);
-  }
-}
-
-bool do_not_expand_this_builtin(const char* name) {
-  char* do_not_expand[] = {"readonly", "set"};
-  for (int i = 0; (unsigned long)i < sizeof(do_not_expand) / sizeof(char*); i++) {
-    if (strcmp(name, do_not_expand[i]) == 0) {
-      return true;
-    }
-  }
-  return false;
-}
-
-VariableType parse_variable_type(const char* value) {
-  if (value == NULL || *value == '\0')
-    return VAR_STRING;
-  while (isspace(*value)) value++;
-  const char* end = value + strlen(value) - 1;
-  while (end > value && isspace(*end)) end--;
-  end++;
-  if ((value[0] == '"' && end[-1] == '"') || (value[0] == '\'' && end[-1] == '\''))
-    return VAR_STRING;
-  char* endptr;
-  strtol(value, &endptr, 10);
-  if (*endptr == '\0')
-    return VAR_INTEGER;
-  if (value[0] == '(' && end[-1] == ')')
-    return VAR_ARRAY;
-  if (value[0] == '{' && end[-1] == '}')
-    return VAR_ASSOCIATIVE_ARRAY;
-  return VAR_STRING;
-}
-
-Variable* resolve_nameref(Variable* var) {
-  if (var == NULL || var->type != VAR_NAMEREF) {
-    return var;
-  }
-  
-  Variable* resolved = NULL;
-  int depth = 0;
-  while (resolved != NULL && resolved->type == VAR_NAMEREF) {
-    if (depth++ > 100) {
-      print_error("Too many levels of indirection");
-      return NULL;
-    }
-    resolved = get_variable(variable_table, resolved->data._str);
-    if (resolved == NULL) {
-      print_error("Variable not found");
-      return NULL;
-    }
-  }
-  return resolved;
-}
-
-bool is_variable_flag_set(va_flag_t* vf, va_flag_t flag) {
-  return (*vf & flag) != 0;
-}
-
-void set_variable_flag(va_flag_t* vf, va_flag_t flag) {
-  *vf |= flag;
-}
-
-void unset_variable_flag(va_flag_t* vf, va_flag_t flag) {
-  *vf &= ~flag;
-}
-
-VariableType get_variable_type(const char* name) {
-  Variable* var = get_variable(variable_table, name);
-  if (var == NULL) {
-    return VAR_STRING;
-  }
-  return var->type;
-}
-
-void set_associative_array_variable(VariableTable* table, const char* name, const char* key, const char* value) {
-  Variable* var = get_variable(table, name);
-  if (var == NULL) {
-    var = set_variable(table, name, "", VAR_ASSOCIATIVE_ARRAY, false);
-  }
-
-  if (var->type != VAR_ASSOCIATIVE_ARRAY) {
-    print_error("Variable is not an associative array");
-    return;
-  }
-
-  va_value_t new_value = string_to_va_value(value, VAR_STRING);
-  map_insert(var->data._map, key, &new_value, sizeof(va_value_t));
-}
-
-char* va_value_to_string(const va_value_t* value) {
-  char* result = NULL;
-  switch (value->type) {
-    case VAR_STRING:
-      result = rstrdup(value->_str);
-      break;
-    case VAR_INTEGER:
-      result = rmalloc(32);
-      snprintf(result, 32, "%lld", value->_number);
-      break;
-    case VAR_ARRAY:
-    case VAR_ASSOCIATIVE_ARRAY:
-      result = rstrdup("(array)");
-      break;
-    default:
-      result = rstrdup("");
-      break;
-  }
-  return result;
-}
-
-va_value_t string_to_va_value(const char* str, VariableType type) {
-  va_value_t result;
-  result.type = type;
-  switch (type) {
-    case VAR_STRING:
-      result._str = rstrdup(str);
-      break;
-    case VAR_INTEGER:
-      result._number = atoll(str);
-      break;
-    case VAR_ARRAY:
-    case VAR_ASSOCIATIVE_ARRAY:
-      result._map = create_map();
-      break;
-    default:
-      result._str = rstrdup("");
-      break;
-  }
-  return result;
-}
-
-void free_va_value(va_value_t* value) {
-  switch (value->type) {
-    case VAR_STRING:
-      rfree(value->_str);
-      break;
-    case VAR_ARRAY:
-      array_free(&value->_array);
-      break;
-    case VAR_ASSOCIATIVE_ARRAY:
-      map_free(value->_map);
-      break;
-    default:
-      break;
-  }
-}
-
-void free_variable(Variable* var) {
-  rfree(var->name);
-  rfree(var->value);
-  free_va_value(&var->data);
-}
-
-void cleanup_variables() {
-  free_variable_table(variable_table);
-}
+bool is_variable_flag_set(va_flag_t* vf, va_flag_t flag) { return (*vf & flag) != 0; }
+void set_variable_flag(va_flag_t* vf, va_flag_t flag) { *vf |= flag; }
+void unset_variable_flag(va_flag_t* vf, va_flag_t flag) { *vf &= ~flag; }

--- a/variable.c
+++ b/variable.c
@@ -172,7 +172,6 @@ void parse_and_set_array(VariableTable* table, const char* name, const char* val
   rfree(trimmed_value);
 }
 
-// { [One]=Delftstack1 [Two]=Delftstack2 [Three]=Delftstack3 }
 void parse_and_set_associative_array(VariableTable* table, const char* name, const char* input) {
   if (input == NULL || table == NULL) return;
   Variable* var = create_new_variable(table, name, VAR_ASSOCIATIVE_ARRAY);
@@ -773,9 +772,11 @@ char* expand_variables(VariableTable* table, const char* input) {
               const char* array_index_end = strchr(array_index_start, ']');
               if (array_index_end) {
                 size_t index_len = (size_t)(array_index_end - array_index_start - 1);
-                char* index_str = rmalloc(index_len + 1);
-                strncpy(index_str, array_index_start + 1, index_len);
-                index_str[index_len] = '\0';
+                char* temp = rmalloc(index_len + 1);
+                strncpy(temp, array_index_start + 1, index_len);
+                temp[index_len] = '\0';
+                char* index_str = expand_variables(table, temp);
+                rfree(temp);
 
                 switch (var->type) {
                   case VAR_ARRAY: {


### PR DESCRIPTION
This PR introduces comprehensive support for arrays and associative arrays within the shell environment.

## Key Updates:
1. **Associative Arrays**: Basic functionality for associative arrays has been implemented, allowing users to store and retrieve values using keys. This includes the ability to create associative arrays with the syntax:
   ```
   { [key1]=value1 [key2]=value2 [key3]=value3 }
   ```
2. **Array Management**: A new array library has been added for parsing and managing arrays, enabling the storage and retrieval of multiple elements by their index.
3. **Value Assignment**: Users can now retrieve values from arrays and associative arrays and assign them to variables, enhancing usability and flexibility.
4. **Dynamic Indexing**: Both arrays and associative arrays have been modified to support variables as indices, in addition to constants and strings.
5. **Memory Management**: Resolved two memory leak issues and enforced stricter GCC compiler options to enhance code stability. This includes measures to prevent type issues, unused value usage, and null pointer dereferencing.

## Notes
**References**: #12  
**Co-authored-by**: Kim Hyunseo <rickroot@fishydino.ru>  
**Contributors**: @urdekcah, @rickroot30

Feel free to modify any part of this, and let me know if you need further adjustments!